### PR TITLE
support standalone func for `wasm_export` macro

### DIFF
--- a/macros/src/wasm_export/func.rs
+++ b/macros/src/wasm_export/func.rs
@@ -1,0 +1,112 @@
+use quote::quote;
+use proc_macro2::TokenStream;
+use super::{tools::*, attrs::WasmExportAttrs};
+use syn::{Error, ItemFn, ReturnType, Visibility};
+
+/// Parses a standalone function and generates the wasm exported function
+pub fn parse(func: &mut ItemFn, mut attrs: WasmExportAttrs) -> Result<TokenStream, Error> {
+    // process the func only if its visibility is pub
+    if let syn::Visibility::Public(_) = func.vis {
+        // create exported func and apply all the modifications
+        let mut export_func = func.clone();
+
+        let return_type = attrs.handle_return_type(&func.sig.output);
+        let WasmExportAttrs { forward_attrs, .. } = attrs;
+
+        // must have Result<> return type
+        if let Some(return_type) = return_type {
+            let org_fn_ident = &func.sig.ident;
+
+            // set exported func name, it is appended with __wasm_export
+            export_func.sig.ident = populate_name(org_fn_ident);
+
+            // forward attributes for exported func
+            export_func.attrs = vec![syn::parse_quote!(#[allow(non_snake_case)])];
+            if !forward_attrs.is_empty() {
+                export_func.attrs.push(syn::parse_quote!(
+                    #[wasm_bindgen(#(#forward_attrs),*)]
+                ));
+            }
+
+            // set exported func return type as WasmEncodedResult
+            export_func.sig.output = syn::parse_quote!(-> WasmEncodedResult<#return_type>);
+
+            // call the original func as body of the exported func
+            export_func.block = Box::new(create_function_call(
+                org_fn_ident,
+                &func.sig.inputs,
+                func.sig.asyncness.is_some(),
+                true,
+            ));
+
+            // Create two functions, original and exporting one
+            let output = quote! {
+                #func
+
+                #export_func
+            };
+
+            Ok(output)
+        } else {
+            let msg = "expected Result<T, E> return type";
+            match &func.sig.output {
+                ReturnType::Default => Err(Error::new_spanned(&func.sig, msg)),
+                ReturnType::Type(_, _) => Err(Error::new_spanned(&func.sig.output, msg)),
+            }
+        }
+    } else {
+        let msg = "expected pub visibility";
+        match &func.vis {
+            Visibility::Inherited => Err(Error::new_spanned(func.sig.fn_token, msg)),
+            _ => Err(Error::new_spanned(&func.vis, msg)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+    use proc_macro2::Span;
+
+    #[test]
+    fn test_parse_happy() {
+        let mut method: ItemFn = parse_quote!(
+            pub async fn some_fn(arg1: String) -> Result<SomeType, Error> {}
+        );
+        let wasm_export_attrs = WasmExportAttrs {
+            should_skip: None,
+            forward_attrs: vec![parse_quote!(some_forward_attr)],
+            unchecked_return_type: Some(("string".to_string(), Span::call_site())),
+        };
+        let result = parse(&mut method, wasm_export_attrs).unwrap();
+        let expected: TokenStream = parse_quote!(
+            pub async fn some_fn(arg1: String) -> Result<SomeType, Error> {}
+            #[allow(non_snake_case)]
+            #[wasm_bindgen(some_forward_attr, unchecked_return_type = "WasmEncodedResult<string>")]
+            pub async fn some_fn__wasm_export(arg1: String) -> WasmEncodedResult<SomeType> {
+                some_fn(arg1).await.into()
+            }
+        );
+        assert_eq!(result.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_parse_unhappy() {
+        // error for pub visibility
+        let mut method: ItemFn = parse_quote!(
+            #[wasm_export(some_forward_attr, unchecked_return_type = "string")]
+            fn some_fn(arg1: String) -> Result<SomeType, Error> {}
+        );
+        let err = parse(&mut method, WasmExportAttrs::default()).unwrap_err();
+        assert_eq!(err.to_string(), "expected pub visibility");
+
+        // error for method with non result return type
+        let mut method: ItemFn = parse_quote!(
+            #[wasm_export(some_forward_attr, unchecked_return_type = "string")]
+            pub fn some_fn(arg1: String) -> SomeType {}
+        );
+        let err = parse(&mut method, WasmExportAttrs::default()).unwrap_err();
+        assert_eq!(err.to_string(), "expected Result<T, E> return type");
+    }
+}

--- a/macros/src/wasm_export/impl_block.rs
+++ b/macros/src/wasm_export/impl_block.rs
@@ -11,7 +11,7 @@ pub fn parse(impl_block: &mut ItemImpl, top_attrs: WasmExportAttrs) -> Result<To
     if let Some((_, span)) = top_attrs.unchecked_return_type {
         return Err(Error::new(
             span,
-            "unexpected `unchecked_return_type` attribute, it can only be used for impl block methods",
+            "unexpected `unchecked_return_type` attribute, it can only be used for impl block methods or standalone functions",
         ));
     }
 
@@ -55,6 +55,7 @@ pub fn parse(impl_block: &mut ItemImpl, top_attrs: WasmExportAttrs) -> Result<To
                         org_fn_ident,
                         &method.sig.inputs,
                         method.sig.asyncness.is_some(),
+                        false,
                     );
 
                     export_items.push(ImplItem::Fn(export_method));
@@ -242,7 +243,7 @@ mod tests {
             ..Default::default()
         };
         let err = parse(&mut method, wasm_export_attr).unwrap_err();
-        assert_eq!(err.to_string(), "unexpected `unchecked_return_type` attribute, it can only be used for impl block methods");
+        assert_eq!(err.to_string(), "unexpected `unchecked_return_type` attribute, it can only be used for impl block methods or standalone functions");
 
         // error for method with non result return type
         let mut method: ItemImpl = parse_quote!(

--- a/macros/src/wasm_export/mod.rs
+++ b/macros/src/wasm_export/mod.rs
@@ -3,6 +3,7 @@ use proc_macro2::TokenStream;
 
 mod attrs;
 mod tools;
+mod func;
 mod impl_block;
 
 /// Starts macro parsing and expansion process by routing the parse towards corresponding
@@ -11,14 +12,15 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream, Error
     let input = syn::parse2(item)?;
     let top_attrs = syn::parse2(attr)?;
 
-    // parse the input as an impl block, this will result in an error as intended
-    // if the macro was used elsewhere, but this can change as more features and
-    // use cases may arrive in future
+    // parse the input as an impl block or standalone function, this will result in an
+    // error as intended if the macro was used elsewhere, but this can change as more
+    // features and use cases may arrive in future
     match input {
+        Item::Fn(mut func) => func::parse(&mut func, top_attrs),
         Item::Impl(mut impl_block) => impl_block::parse(&mut impl_block, top_attrs),
         _ => Err(Error::new_spanned(
             &input,
-            "unexpected input, wasm_export macro is only applicable to impl blocks",
+            "unexpected input, wasm_export macro is only applicable to impl blocks or standalone functions",
         )),
     }
 }

--- a/macros/tests/happy/func.test.expanded.rs
+++ b/macros/tests/happy/func.test.expanded.rs
@@ -1,0 +1,25 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+struct TestStruct;
+#[some_external_macro]
+pub async fn some_fn(arg: String) -> Result<TestStruct, Error> {
+    Ok(TestStruct)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(
+    js_name = "someSelfMethod",
+    some_wbg_attr,
+    some_other_wbg_attr = something,
+    unchecked_return_type = "WasmEncodedResult<TestStruct>"
+)]
+pub async fn some_fn__wasm_export(arg: String) -> WasmEncodedResult<TestStruct> {
+    some_fn(arg).await.into()
+}
+pub fn some_other_fn() -> Result<Vec<u8>, Error> {
+    Ok(::alloc::vec::Vec::new())
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<number[]>")]
+pub fn some_other_fn__wasm_export() -> WasmEncodedResult<Vec<u8>> {
+    some_other_fn().into()
+}

--- a/macros/tests/happy/func.test.rs
+++ b/macros/tests/happy/func.test.rs
@@ -1,0 +1,15 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[some_external_macro]
+#[wasm_export(js_name = "someSelfMethod", some_wbg_attr, some_other_wbg_attr = something)]
+pub async fn some_fn(arg: String) -> Result<TestStruct, Error> {
+    Ok(TestStruct)
+}
+
+#[wasm_export(unchecked_return_type = "number[]")]
+pub fn some_other_fn() -> Result<Vec<u8>, Error> {
+    Ok(vec![])
+}

--- a/macros/tests/unhappy/expected_pub_vis.test.rs
+++ b/macros/tests/unhappy/expected_pub_vis.test.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+#[wasm_export]
+fn some_fn(arg: String) -> Result<String, Error> {
+    Ok(String::new())
+}
+
+#[wasm_export]
+pub(crate) fn some_other_fn(arg: String) -> Result<String, Error> {
+    Ok(String::new())
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_pub_vis.test.stderr
+++ b/macros/tests/unhappy/expected_pub_vis.test.stderr
@@ -1,0 +1,11 @@
+error: expected pub visibility
+ --> tests/unhappy/expected_pub_vis.test.rs:5:1
+  |
+5 | fn some_fn(arg: String) -> Result<String, Error> {
+  | ^^
+
+error: expected pub visibility
+  --> tests/unhappy/expected_pub_vis.test.rs:10:1
+   |
+10 | pub(crate) fn some_other_fn(arg: String) -> Result<String, Error> {
+   | ^^^^^^^^^^

--- a/macros/tests/unhappy/unexpected_input.test.rs
+++ b/macros/tests/unhappy/unexpected_input.test.rs
@@ -8,9 +8,6 @@ struct TestStruct;
 enum TestEnum {}
 
 #[wasm_export]
-fn test_fn() {}
-
-#[wasm_export]
 type TestType = u8;
 
 #[wasm_export]

--- a/macros/tests/unhappy/unexpected_input.test.stderr
+++ b/macros/tests/unhappy/unexpected_input.test.stderr
@@ -1,41 +1,35 @@
-error: unexpected input, wasm_export macro is only applicable to impl blocks
+error: unexpected input, wasm_export macro is only applicable to impl blocks or standalone functions
  --> tests/unhappy/unexpected_input.test.rs:5:1
   |
 5 | struct TestStruct;
   | ^^^^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
+error: unexpected input, wasm_export macro is only applicable to impl blocks or standalone functions
  --> tests/unhappy/unexpected_input.test.rs:8:1
   |
 8 | enum TestEnum {}
   | ^^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
+error: unexpected input, wasm_export macro is only applicable to impl blocks or standalone functions
   --> tests/unhappy/unexpected_input.test.rs:11:1
    |
-11 | fn test_fn() {}
-   | ^^^^^^^^^^^^^^^
-
-error: unexpected input, wasm_export macro is only applicable to impl blocks
-  --> tests/unhappy/unexpected_input.test.rs:14:1
-   |
-14 | type TestType = u8;
+11 | type TestType = u8;
    | ^^^^^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
-  --> tests/unhappy/unexpected_input.test.rs:17:1
+error: unexpected input, wasm_export macro is only applicable to impl blocks or standalone functions
+  --> tests/unhappy/unexpected_input.test.rs:14:1
    |
-17 | mod test_mod {}
+14 | mod test_mod {}
    | ^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
-  --> tests/unhappy/unexpected_input.test.rs:20:1
+error: unexpected input, wasm_export macro is only applicable to impl blocks or standalone functions
+  --> tests/unhappy/unexpected_input.test.rs:17:1
    |
-20 | const TEST_COST: u8 = 1;
+17 | const TEST_COST: u8 = 1;
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
-  --> tests/unhappy/unexpected_input.test.rs:23:1
+error: unexpected input, wasm_export macro is only applicable to impl blocks or standalone functions
+  --> tests/unhappy/unexpected_input.test.rs:20:1
    |
-23 | static TEST_STATIC: u8 = 1;
+20 | static TEST_STATIC: u8 = 1;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/unexpected_unchecked_ret_type_attr.test.stderr
+++ b/macros/tests/unhappy/unexpected_unchecked_ret_type_attr.test.stderr
@@ -1,4 +1,4 @@
-error: unexpected `unchecked_return_type` attribute, it can only be used for impl block methods
+error: unexpected `unchecked_return_type` attribute, it can only be used for impl block methods or standalone functions
  --> tests/unhappy/unexpected_unchecked_ret_type_attr.test.rs:6:15
   |
 6 | #[wasm_export(unchecked_return_type = "string")]


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
resolves #17 
currently `wasm_export` macro only supports `impl` blocks with its inner methods, however standalone functions are needed to be supported with pretty much similar logic, this PR adds support for standalone functions to `wasm_export` macro.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
