### PR TITLE
Adding standalone function support to wasm export macro

### DIFF
--- a/macros/src/wasm_export/impl_block.rs
+++ b/macros/src/wasm_export/impl_block.rs
@@ -51,10 +51,11 @@ pub fn parse(impl_block: &mut ItemImpl, top_attrs: WasmExportAttrs) -> Result<To
                         syn::parse_quote!(-> WasmEncodedResult<#return_type>);
 
                     // call the original method as body of the exported method
-                    export_method.block = create_function_call(
+                    export_method.block = create_function_call_unified(
                         org_fn_ident,
                         &method.sig.inputs,
                         method.sig.asyncness.is_some(),
+                        FunctionContext::Method,
                     );
 
                     export_items.push(ImplItem::Fn(export_method));

--- a/macros/src/wasm_export/mod.rs
+++ b/macros/src/wasm_export/mod.rs
@@ -4,6 +4,7 @@ use proc_macro2::TokenStream;
 mod attrs;
 mod tools;
 mod impl_block;
+mod standalone_fn;
 
 /// Starts macro parsing and expansion process by routing the parse towards corresponding
 /// parse logic based on input type
@@ -11,14 +12,13 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream, Error
     let input = syn::parse2(item)?;
     let top_attrs = syn::parse2(attr)?;
 
-    // parse the input as an impl block, this will result in an error as intended
-    // if the macro was used elsewhere, but this can change as more features and
-    // use cases may arrive in future
+    // parse the input based on its type
     match input {
         Item::Impl(mut impl_block) => impl_block::parse(&mut impl_block, top_attrs),
+        Item::Fn(mut func) => standalone_fn::parse(&mut func, top_attrs),
         _ => Err(Error::new_spanned(
             &input,
-            "unexpected input, wasm_export macro is only applicable to impl blocks",
+            "unexpected input, wasm_export macro is only applicable to impl blocks or functions",
         )),
     }
 }

--- a/macros/src/wasm_export/standalone_fn.rs
+++ b/macros/src/wasm_export/standalone_fn.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use syn::{punctuated::Punctuated, Error, ItemFn, Meta, ReturnType, Token};
 use super::{
     attrs::{handle_attrs_sequence, AttrKeys, WasmExportAttrs},
-    tools::{create_standalone_function_call, extend_err_msg, populate_name},
+    tools::{create_function_call_unified, extend_err_msg, populate_name, FunctionContext},
 };
 
 /// 1. Attributes to forward to wasm_bindgen.
@@ -66,10 +66,11 @@ pub fn parse(func: &mut ItemFn, mut top_attrs: WasmExportAttrs) -> Result<TokenS
     export_fn.sig.output = syn::parse_quote!(-> WasmEncodedResult<#original_return_type>);
 
     // Set export function body to call the original function
-    export_fn.block = Box::new(create_standalone_function_call(
+    export_fn.block = Box::new(create_function_call_unified(
         original_fn_ident,
         &func.sig.inputs,
         func.sig.asyncness.is_some(), // Pass true if original fn is async
+        FunctionContext::Standalone,
     ));
 
     // 4. Combine original and exported function tokens

--- a/macros/src/wasm_export/standalone_fn.rs
+++ b/macros/src/wasm_export/standalone_fn.rs
@@ -1,0 +1,269 @@
+use quote::quote;
+use proc_macro2::{Span, TokenStream};
+use syn::{punctuated::Punctuated, Error, ItemFn, Meta, ReturnType, Token};
+use super::{
+    attrs::{handle_attrs_sequence, AttrKeys, WasmExportAttrs},
+    tools::{create_standalone_function_call, extend_err_msg, populate_name},
+};
+
+/// Parses a standalone function and generates the wasm exported function
+pub fn parse(func: &mut ItemFn, mut top_attrs: WasmExportAttrs) -> Result<TokenStream, Error> {
+    // 1. Handle function-level attributes
+    let (fn_forward_attrs, return_type_override, should_skip) = handle_fn_attrs(func)?;
+
+    if should_skip {
+        // If skipped, just return the original function definition (with wasm_export attribute removed)
+        return Ok(quote!(#func));
+    }
+
+    // Combine top-level and function-level forward attributes
+    top_attrs.forward_attrs.extend(fn_forward_attrs);
+    top_attrs.unchecked_return_type = return_type_override; // Use fn-level override if present
+
+    // 2. Validate return type and determine the inner type T for Result<T, E>
+    let original_return_type = match top_attrs.handle_return_type(&func.sig.output) {
+        Some(ty) => ty,
+        None => {
+            let msg = "expected Result<T, E> return type";
+            return match &func.sig.output {
+                ReturnType::Default => Err(Error::new_spanned(&func.sig, msg)),
+                ReturnType::Type(_, _) => Err(Error::new_spanned(&func.sig.output, msg)),
+            };
+        }
+    };
+
+    // 3. Create the export function
+    let original_fn_ident = &func.sig.ident;
+    let mut export_fn = func.clone();
+
+    // Set export function name (e.g., original_name__wasm_export)
+    export_fn.sig.ident = populate_name(original_fn_ident);
+
+    // Remove non-wasm_bindgen attributes (they stay on the original function)
+    export_fn.attrs.clear();
+
+    // Add #[wasm_bindgen(...)] attribute
+    let combined_forward_attrs = &top_attrs.forward_attrs;
+    if !combined_forward_attrs.is_empty() {
+        export_fn.attrs.push(syn::parse_quote!(
+            #[wasm_bindgen(#(#combined_forward_attrs),*)]
+        ));
+    } else {
+        // Add wasm_bindgen even if no specific attrs were forwarded
+        export_fn.attrs.push(syn::parse_quote!(#[wasm_bindgen]));
+    }
+    // Allow non_snake_case for the generated function name
+    export_fn
+        .attrs
+        .push(syn::parse_quote!(#[allow(non_snake_case)]));
+
+    // Set export function return type to WasmEncodedResult<T>
+    export_fn.sig.output = syn::parse_quote!(-> WasmEncodedResult<#original_return_type>);
+
+    // Set export function body to call the original function
+    export_fn.block = Box::new(create_standalone_function_call(
+        original_fn_ident,
+        &func.sig.inputs,
+        func.sig.asyncness.is_some(), // Pass true if original fn is async
+    ));
+
+    // 4. Combine original and exported function tokens
+    let output = quote! {
+        #func // The original function (with wasm_export attr removed)
+
+        #export_fn
+    };
+
+    Ok(output)
+}
+
+/// Handles wasm_export macro attributes for a standalone function.
+/// This is similar to `handle_method_attrs` but adapted for ItemFn.
+fn handle_fn_attrs(func: &mut ItemFn) -> Result<(Vec<Meta>, Option<(String, Span)>, bool), Error> {
+    let mut keep_indices = Vec::new();
+    let mut wasm_export_attrs = WasmExportAttrs::default();
+
+    for (_, attr) in func.attrs.iter().enumerate() {
+        if attr.path().is_ident(AttrKeys::WASM_EXPORT) {
+            // Skip parsing if there are no nested attributes (e.g., #[wasm_export])
+            if !matches!(attr.meta, Meta::Path(_)) {
+                let nested_seq = attr
+                    .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                    .map_err(extend_err_msg(
+                        " as wasm_export attributes must be delimited by comma",
+                    ))?;
+                handle_attrs_sequence(nested_seq, &mut wasm_export_attrs)?;
+            }
+            // Mark this attribute for removal
+            keep_indices.push(false);
+        } else {
+            // Mark other attributes to be kept on the original function
+            keep_indices.push(true);
+        }
+    }
+
+    // Remove wasm_export attributes from the original function
+    let mut keep_iter = keep_indices.into_iter();
+    func.attrs.retain(|_| keep_iter.next().unwrap_or(true));
+
+    // Cannot use skip and unchecked_return_type together on the same function
+    if let (Some(skip_span), Some((_, urt_span))) = (
+        wasm_export_attrs.should_skip,
+        wasm_export_attrs.unchecked_return_type.as_ref(),
+    ) {
+        let mut err = Error::new(
+            skip_span,
+            "`skip` attribute cannot be used together with `unchecked_return_type`",
+        );
+        err.combine(Error::new(
+            *urt_span,
+            "`unchecked_return_type` attribute cannot be used together with `skip`",
+        ));
+        return Err(err);
+    }
+
+    Ok((
+        wasm_export_attrs.forward_attrs,
+        wasm_export_attrs.unchecked_return_type,
+        wasm_export_attrs.should_skip.is_some(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn test_parse_standalone_fn_basic() {
+        let mut func: ItemFn = parse_quote!(
+            #[wasm_export(js_name = "exportedName")]
+            pub async fn my_async_func(a: String) -> Result<u32, JsValue> {
+                Ok(a.len() as u32)
+            }
+        );
+        let top_attrs = WasmExportAttrs::default(); // No top-level attrs
+        let result = parse(&mut func, top_attrs).unwrap();
+
+        let expected: TokenStream = parse_quote!(
+            pub async fn my_async_func(a: String) -> Result<u32, JsValue> {
+                Ok(a.len() as u32)
+            }
+
+            #[wasm_bindgen(
+                js_name = "exportedName",
+                unchecked_return_type = "WasmEncodedResult<u32>"
+            )]
+            #[allow(non_snake_case)]
+            pub async fn my_async_func__wasm_export(a: String) -> WasmEncodedResult<u32> {
+                my_async_func(a).await.into()
+            }
+        );
+        assert_eq!(result.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_parse_standalone_fn_with_top_attrs() {
+        let mut func: ItemFn = parse_quote!(
+            #[wasm_export(js_name = "specificName")]
+            fn my_sync_func() -> Result<(), JsValue> {
+                Ok(())
+            }
+        );
+        // Simulate #[wasm_export(catch)] on top
+        let top_attrs: WasmExportAttrs = syn::parse_quote!(catch);
+        let result = parse(&mut func, top_attrs).unwrap();
+
+        let expected: TokenStream = parse_quote!(
+            fn my_sync_func() -> Result<(), JsValue> {
+                Ok(())
+            }
+
+            #[wasm_bindgen(
+                catch,
+                js_name = "specificName",
+                unchecked_return_type = "WasmEncodedResult<()>"
+            )]
+            #[allow(non_snake_case)]
+            fn my_sync_func__wasm_export() -> WasmEncodedResult<()> {
+                my_sync_func().into()
+            }
+        );
+        assert_eq!(result.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_parse_standalone_fn_skip() {
+        let mut func: ItemFn = parse_quote!(
+            #[other_attr]
+            #[wasm_export(skip)]
+            pub fn skipped_func() -> Result<String, JsValue> {
+                Ok("hello".to_string())
+            }
+        );
+        let top_attrs = WasmExportAttrs::default();
+        let result = parse(&mut func, top_attrs).unwrap();
+
+        let expected: TokenStream = parse_quote!(
+            #[other_attr]
+            pub fn skipped_func() -> Result<String, JsValue> {
+                Ok("hello".to_string())
+            }
+        );
+        // The skipped function should just be the original function, with wasm_export removed
+        assert_eq!(result.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_parse_standalone_fn_return_override() {
+        let mut func: ItemFn = parse_quote!(
+            #[wasm_export(unchecked_return_type = "MyJsType")]
+            pub fn override_func() -> Result<MyRustType, JsValue> {
+                Ok(MyRustType)
+            }
+        );
+        let top_attrs = WasmExportAttrs::default();
+        let result = parse(&mut func, top_attrs).unwrap();
+
+        let expected: TokenStream = parse_quote!(
+            pub fn override_func() -> Result<MyRustType, JsValue> {
+                Ok(MyRustType)
+            }
+
+            #[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<MyJsType>")]
+            #[allow(non_snake_case)]
+            pub fn override_func__wasm_export() -> WasmEncodedResult<MyRustType> {
+                override_func().into()
+            }
+        );
+        assert_eq!(result.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_parse_standalone_fn_no_result_error() {
+        let mut func: ItemFn = parse_quote!(
+            #[wasm_export]
+            pub fn not_a_result() -> String {
+                "hello".to_string()
+            }
+        );
+        let top_attrs = WasmExportAttrs::default();
+        let err = parse(&mut func, top_attrs).unwrap_err();
+        assert_eq!(err.to_string(), "expected Result<T, E> return type");
+    }
+
+    #[test]
+    fn test_parse_standalone_fn_skip_and_override_error() {
+        let mut func: ItemFn = parse_quote!(
+            #[wasm_export(skip, unchecked_return_type = "string")]
+            pub fn invalid_attrs() -> Result<(), JsValue> {
+                Ok(())
+            }
+        );
+        let top_attrs = WasmExportAttrs::default();
+        let err = parse(&mut func, top_attrs).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("`skip` attribute cannot be used together with `unchecked_return_type`"));
+    }
+}

--- a/macros/src/wasm_export/tools.rs
+++ b/macros/src/wasm_export/tools.rs
@@ -36,9 +36,9 @@ pub fn create_function_call_unified(
         }
         FunctionContext::Standalone => {
             if has_self_receiver {
-                 return syn::parse_quote!({
-                     compile_error!("Standalone functions cannot have a 'self' receiver")
-                 });
+                return syn::parse_quote!({
+                    compile_error!("Standalone functions cannot have a 'self' receiver")
+                });
             }
             quote! { #fn_name(#(#args),*) }
         }
@@ -129,7 +129,8 @@ mod tests {
             .unwrap();
         let fn_name = Ident::new("some_name", Span::call_site());
         let is_async = true;
-        let result = create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Method);
+        let result =
+            create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Method);
         // Expected: Self::some_name(arg1, arg2).await.into() -> Note: parse_quote! needs parentheses around tuple args
         let expected: Block = parse_quote!({ Self::some_name((arg1, arg2)).await.into() });
         assert_eq!(format!("{:?}", result), format!("{:?}", expected)); // Compare string representation for complex Block types
@@ -143,12 +144,13 @@ mod tests {
             .unwrap();
         let fn_name = Ident::new("some_name", Span::call_site());
         let is_async = false;
-        let result = create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Method);
+        let result =
+            create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Method);
         let expected: Block = parse_quote!({ self.some_name(arg1, arg2).into() });
-         assert_eq!(format!("{:?}", result), format!("{:?}", expected));
+        assert_eq!(format!("{:?}", result), format!("{:?}", expected));
     }
 
-     #[test]
+    #[test]
     fn test_create_function_call_unified_standalone_sync() {
         let stream = TokenStream::from_str(r#"arg1: String, arg2: u8"#).unwrap();
         let inputs = Punctuated::<FnArg, Comma>::parse_terminated
@@ -156,9 +158,10 @@ mod tests {
             .unwrap();
         let fn_name = Ident::new("some_standalone_fn", Span::call_site());
         let is_async = false;
-        let result = create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Standalone);
+        let result =
+            create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Standalone);
         let expected: Block = parse_quote!({ some_standalone_fn(arg1, arg2).into() });
-         assert_eq!(format!("{:?}", result), format!("{:?}", expected));
+        assert_eq!(format!("{:?}", result), format!("{:?}", expected));
     }
 
     #[test]
@@ -169,12 +172,13 @@ mod tests {
             .unwrap();
         let fn_name = Ident::new("another_standalone", Span::call_site());
         let is_async = true;
-        let result = create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Standalone);
+        let result =
+            create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Standalone);
         let expected: Block = parse_quote!({ another_standalone(arg1).await.into() });
         assert_eq!(format!("{:?}", result), format!("{:?}", expected));
     }
 
-     #[test]
+    #[test]
     fn test_create_function_call_unified_standalone_with_self_error() {
         // This test verifies that providing a 'self' receiver with Standalone context triggers compile error
         let stream = TokenStream::from_str(r#"&self, arg1: String"#).unwrap();
@@ -183,11 +187,12 @@ mod tests {
             .unwrap();
         let fn_name = Ident::new("standalone_error_fn", Span::call_site());
         let is_async = false;
-        let result = create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Standalone);
-        let expected: Block = parse_quote!({ compile_error!("Standalone functions cannot have a 'self' receiver") });
-         assert_eq!(format!("{:?}", result), format!("{:?}", expected));
+        let result =
+            create_function_call_unified(&fn_name, &inputs, is_async, FunctionContext::Standalone);
+        let expected: Block =
+            parse_quote!({ compile_error!("Standalone functions cannot have a 'self' receiver") });
+        assert_eq!(format!("{:?}", result), format!("{:?}", expected));
     }
-
 
     #[test]
     fn test_collect_function_arguments() {

--- a/macros/src/wasm_export/tools.rs
+++ b/macros/src/wasm_export/tools.rs
@@ -32,6 +32,28 @@ pub fn create_function_call(
     }
 }
 
+/// Creates a function call expression for a standalone function.
+pub fn create_standalone_function_call(
+    fn_name: &Ident,
+    inputs: &Punctuated<FnArg, Comma>,
+    is_async: bool,
+) -> Block {
+    // Standalone functions never have a 'self' receiver in the context of the call itself
+    let (_, args) = collect_function_arguments(inputs);
+    // Direct function call using its identifier
+    let call_expr = quote! { #fn_name(#(#args),*) };
+
+    if is_async {
+        syn::parse_quote!({
+            #call_expr.await.into()
+        })
+    } else {
+        syn::parse_quote!({
+            #call_expr.into()
+        })
+    }
+}
+
 /// Collects function arguments and determines if the function has a self receiver
 pub fn collect_function_arguments(inputs: &Punctuated<FnArg, Comma>) -> (bool, Vec<TokenStream>) {
     let mut has_self_receiver = false;

--- a/macros/tests/unhappy/unexpected_input.test.rs
+++ b/macros/tests/unhappy/unexpected_input.test.rs
@@ -8,9 +8,6 @@ struct TestStruct;
 enum TestEnum {}
 
 #[wasm_export]
-fn test_fn() {}
-
-#[wasm_export]
 type TestType = u8;
 
 #[wasm_export]

--- a/macros/tests/unhappy/unexpected_input.test.stderr
+++ b/macros/tests/unhappy/unexpected_input.test.stderr
@@ -1,41 +1,35 @@
-error: unexpected input, wasm_export macro is only applicable to impl blocks
+error: unexpected input, wasm_export macro is only applicable to impl blocks or functions
  --> tests/unhappy/unexpected_input.test.rs:5:1
   |
 5 | struct TestStruct;
   | ^^^^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
+error: unexpected input, wasm_export macro is only applicable to impl blocks or functions
  --> tests/unhappy/unexpected_input.test.rs:8:1
   |
 8 | enum TestEnum {}
   | ^^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
+error: unexpected input, wasm_export macro is only applicable to impl blocks or functions
   --> tests/unhappy/unexpected_input.test.rs:11:1
    |
-11 | fn test_fn() {}
-   | ^^^^^^^^^^^^^^^
-
-error: unexpected input, wasm_export macro is only applicable to impl blocks
-  --> tests/unhappy/unexpected_input.test.rs:14:1
-   |
-14 | type TestType = u8;
+11 | type TestType = u8;
    | ^^^^^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
-  --> tests/unhappy/unexpected_input.test.rs:17:1
+error: unexpected input, wasm_export macro is only applicable to impl blocks or functions
+  --> tests/unhappy/unexpected_input.test.rs:14:1
    |
-17 | mod test_mod {}
+14 | mod test_mod {}
    | ^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
-  --> tests/unhappy/unexpected_input.test.rs:20:1
+error: unexpected input, wasm_export macro is only applicable to impl blocks or functions
+  --> tests/unhappy/unexpected_input.test.rs:17:1
    |
-20 | const TEST_COST: u8 = 1;
+17 | const TEST_COST: u8 = 1;
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unexpected input, wasm_export macro is only applicable to impl blocks
-  --> tests/unhappy/unexpected_input.test.rs:23:1
+error: unexpected input, wasm_export macro is only applicable to impl blocks or functions
+  --> tests/unhappy/unexpected_input.test.rs:20:1
    |
-23 | static TEST_STATIC: u8 = 1;
+20 | static TEST_STATIC: u8 = 1;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.wasm/issues/17

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- ~[ ] included screenshots (if this involves a front-end change)~

fix https://github.com/rainlanguage/rain.wasm/issues/17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for exporting standalone functions using the `#[wasm_export]` macro, alongside implementation blocks.
  - Introduced unified function call generation handling both methods and standalone functions with context-aware logic.
- **Bug Fixes**
  - Improved error messages to clarify that the macro applies to both functions and impl blocks.
  - Enforced error handling for invalid `self` usage in standalone functions.
- **Tests**
  - Expanded test coverage for standalone function exports, attribute combinations, and error scenarios.
- **Documentation**
  - Updated comments and error descriptions to reflect the macro’s broader applicability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->