### PR TITLE
Fix standalone function macro parse implementation issues

### DIFF
--- a/macros/src/wasm_export/impl_block.rs
+++ b/macros/src/wasm_export/impl_block.rs
@@ -11,7 +11,7 @@ pub fn parse(impl_block: &mut ItemImpl, top_attrs: WasmExportAttrs) -> Result<To
     if let Some((_, span)) = top_attrs.unchecked_return_type {
         return Err(Error::new(
             span,
-            "unexpected `unchecked_return_type` attribute, it can only be used for impl block methods",
+            "unexpected `unchecked_return_type` attribute, it can only be used for impl block methods or standalone functions",
         ));
     }
 
@@ -243,7 +243,7 @@ mod tests {
             ..Default::default()
         };
         let err = parse(&mut method, wasm_export_attr).unwrap_err();
-        assert_eq!(err.to_string(), "unexpected `unchecked_return_type` attribute, it can only be used for impl block methods");
+        assert_eq!(err.to_string(), "unexpected `unchecked_return_type` attribute, it can only be used for impl block methods or standalone functions");
 
         // error for method with non result return type
         let mut method: ItemImpl = parse_quote!(

--- a/macros/src/wasm_export/standalone_fn.rs
+++ b/macros/src/wasm_export/standalone_fn.rs
@@ -89,7 +89,7 @@ mod tests {
                 Ok(a.len() as u32)
             }
         );
-        let mut top_attrs = WasmExportAttrs::default(); // No top-level attrs
+        let top_attrs = WasmExportAttrs::default(); // No top-level attrs
         let result = parse(&mut func, top_attrs).unwrap();
 
         let expected: TokenStream = parse_quote!(

--- a/macros/tests/happy/func.test.expanded.rs
+++ b/macros/tests/happy/func.test.expanded.rs
@@ -1,0 +1,25 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+struct TestStruct;
+#[some_external_macro]
+pub async fn some_fn(arg: String) -> Result<TestStruct, Error> {
+    Ok(TestStruct)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(
+    js_name = "someSelfMethod",
+    some_wbg_attr,
+    some_other_wbg_attr = something,
+    unchecked_return_type = "WasmEncodedResult<TestStruct>"
+)]
+pub async fn some_fn__wasm_export(arg: String) -> WasmEncodedResult<TestStruct> {
+    some_fn(arg).await.into()
+}
+pub fn some_other_fn() -> Result<Vec<u8>, Error> {
+    Ok(::alloc::vec::Vec::new())
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<number[]>")]
+pub fn some_other_fn__wasm_export() -> WasmEncodedResult<Vec<u8>> {
+    some_other_fn().into()
+}

--- a/macros/tests/happy/func.test.rs
+++ b/macros/tests/happy/func.test.rs
@@ -1,0 +1,15 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[some_external_macro]
+#[wasm_export(js_name = "someSelfMethod", some_wbg_attr, some_other_wbg_attr = something)]
+pub async fn some_fn(arg: String) -> Result<TestStruct, Error> {
+    Ok(TestStruct)
+}
+
+#[wasm_export(unchecked_return_type = "number[]")]
+pub fn some_other_fn() -> Result<Vec<u8>, Error> {
+    Ok(vec![])
+}

--- a/macros/tests/unhappy/expected_pub_vis.test.rs
+++ b/macros/tests/unhappy/expected_pub_vis.test.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+#[wasm_export]
+fn some_fn(arg: String) -> Result<String, Error> {
+    Ok(String::new())
+}
+
+#[wasm_export]
+pub(crate) fn some_other_fn(arg: String) -> Result<String, Error> {
+    Ok(String::new())
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_pub_vis.test.stderr
+++ b/macros/tests/unhappy/expected_pub_vis.test.stderr
@@ -1,0 +1,11 @@
+error: expected pub visibility
+ --> tests/unhappy/expected_pub_vis.test.rs:5:1
+  |
+5 | fn some_fn(arg: String) -> Result<String, Error> {
+  | ^^
+
+error: expected pub visibility
+  --> tests/unhappy/expected_pub_vis.test.rs:10:1
+   |
+10 | pub(crate) fn some_other_fn(arg: String) -> Result<String, Error> {
+   | ^^^^^^^^^^

--- a/macros/tests/unhappy/unexpected_skip.test.rs
+++ b/macros/tests/unhappy/unexpected_skip.test.rs
@@ -10,4 +10,9 @@ impl TestStruct {
     }
 }
 
+#[wasm_export(skip)]
+pub fn some_fn(arg: String) -> Result<String, Error> {
+    Ok(String::new())
+}
+
 fn main() {}

--- a/macros/tests/unhappy/unexpected_skip.test.stderr
+++ b/macros/tests/unhappy/unexpected_skip.test.stderr
@@ -3,3 +3,9 @@ error: unexpected `skip` attribute, it is only valid for methods of an impl bloc
   |
 6 | #[wasm_export(skip)]
   |               ^^^^
+
+error: unexpected `skip` attribute, it is only valid for methods of an impl block
+  --> tests/unhappy/unexpected_skip.test.rs:13:15
+   |
+13 | #[wasm_export(skip)]
+   |               ^^^^

--- a/macros/tests/unhappy/unexpected_unchecked_ret_type_attr.test.stderr
+++ b/macros/tests/unhappy/unexpected_unchecked_ret_type_attr.test.stderr
@@ -1,4 +1,4 @@
-error: unexpected `unchecked_return_type` attribute, it can only be used for impl block methods
+error: unexpected `unchecked_return_type` attribute, it can only be used for impl block methods or standalone functions
  --> tests/unhappy/unexpected_unchecked_ret_type_attr.test.rs:6:15
   |
 6 | #[wasm_export(unchecked_return_type = "string")]


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Fix some implementation issues and bugs with standalone function macro logic, which are:
- Standalone functions, unlike impl blocks that have inner methods, that can have their own set of attributes, dont have inner attributes, and only have top attributes that are given to the entry point of proc macro API in the first arg (second arg is the item itself), eg: 
```rust
// entry point API of proc macro, top attributes and items are provided separately
#[proc_macro_attribute]
pub fn wasm_export(attr: TokenStream, item: TokenStream) -> TokenStream
``` 
which is handled already in `impl Parse for WasmExportAttrs`, so its incorrect to check and parse inner attributes inside standalone function parsing logic, which currently happens in `macros/src/wasm_export/standalone_fn::handle_fn_attrs` which is pretty much a duplicate of `macros/src/wasm_export/impl_block::handle_method_attrs`, so we need to remove that as it doesnt really do amything and might actually cause unintended bugs and behavior.

- for Wasm bindgen, standalone functions must have pub visibiltiy, any function that isn't pub can't be exposed to Wasm bindgen as it throws error, so we need to check for that in `parse` logic

- `skip` attribute doesn't really mean anything in context of standalone functions, if the idea is to not include a function in in the wasm bindgen output, then simply we should not use `wasm_export` macro for it in the first place, rather than use it and specify skip for it and then return it unchanged from the parse logic, so we should error if skip is used for a standalone function as it is clearly stated in the skip attrs documentation:
<img width="692" alt="Screenshot 2025-05-08 at 10 24 30 PM" src="https://github.com/user-attachments/assets/b85acb72-f97b-4b2f-bdfc-dd8dc0a244f9" />

As a general rule, the less manipulation takes place for function the more secure it is, so having a `skip` attribute for standalone function when it doesnt really do anything but rather might cause issues is not recommended.

- for unit testing standalone functions parse logic, since it only can have top attributes, we can't specify attrs in the `parse_quote` content, rather we should provide such attributes through `WasmExportAttrs` struct, that is because as mentioned above, proc macro already parses and provides the top level attrs on entry point separately. so there has been some fixes for the affected unit tests as those were not correctly testing the real world situation.

- fix some other minor issues with unit tests

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This PR addresses and fixes the issues mentioned above and adds more unit and macro tests.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for exporting both async and sync Rust functions to WebAssembly with custom attributes and return type conversions.
  - Introduced new tests to verify correct handling of top-level attributes and error cases for visibility and return types.

- **Bug Fixes**
  - Updated error messages to clarify attribute usage for `unchecked_return_type` and `skip`, improving guidance when used incorrectly.

- **Refactor**
  - Simplified attribute handling for exported standalone functions by enforcing top-level attribute usage only and removing support for function-level `skip`.

- **Tests**
  - Added and updated test cases to reflect new attribute handling rules and to ensure correct error reporting for visibility and attribute misuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->