### PR TITLE
Update preserve js class to cast error into wasm encoded result

### DIFF
--- a/macros/src/wasm_export/builder.rs
+++ b/macros/src/wasm_export/builder.rs
@@ -281,7 +281,8 @@ mod tests {
                         let wasm_error: WasmEncodedError = error.into();
                         Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
                             .unwrap();
-                        Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
+                        Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into())
+                            .unwrap();
                     }
                 };
                 obj.into()
@@ -338,7 +339,8 @@ mod tests {
                         let wasm_error: WasmEncodedError = error.into();
                         Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
                             .unwrap();
-                        Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
+                        Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into())
+                            .unwrap();
                     }
                 };
                 obj.into()

--- a/macros/src/wasm_export/builder.rs
+++ b/macros/src/wasm_export/builder.rs
@@ -178,8 +178,9 @@ impl WasmExportFunctionBuilder {
                         Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED).unwrap();
                     }
                     Err(error) => {
+                        let wasm_error: WasmEncodedError = error.into();
                         Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED).unwrap();
-                        Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                        Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                     }
                 };
 
@@ -277,9 +278,10 @@ mod tests {
                             .unwrap();
                     }
                     Err(error) => {
+                        let wasm_error: WasmEncodedError = error.into();
                         Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
                             .unwrap();
-                        Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                        Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                     }
                 };
                 obj.into()
@@ -333,9 +335,10 @@ mod tests {
                             .unwrap();
                     }
                     Err(error) => {
+                        let wasm_error: WasmEncodedError = error.into();
                         Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
                             .unwrap();
-                        Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                        Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                     }
                 };
                 obj.into()
@@ -386,8 +389,9 @@ mod tests {
                     Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED).unwrap();
                 }
                 Err(error) => {
+                    let wasm_error: WasmEncodedError = error.into();
                     Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED).unwrap();
-                    Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                    Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                 }
             };
             obj.into()
@@ -412,8 +416,9 @@ mod tests {
                     Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED).unwrap();
                 }
                 Err(error) => {
+                    let wasm_error: WasmEncodedError = error.into();
                     Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED).unwrap();
-                    Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                    Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                 }
             };
             obj.into()
@@ -463,8 +468,9 @@ mod tests {
                     Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED).unwrap();
                 }
                 Err(error) => {
+                    let wasm_error: WasmEncodedError = error.into();
                     Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED).unwrap();
-                    Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                    Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                 }
             };
             obj.into()
@@ -489,8 +495,9 @@ mod tests {
                     Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED).unwrap();
                 }
                 Err(error) => {
+                    let wasm_error: WasmEncodedError = error.into();
                     Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED).unwrap();
-                    Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                    Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                 }
             };
             obj.into()
@@ -533,8 +540,9 @@ mod tests {
                     Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED).unwrap();
                 }
                 Err(error) => {
+                    let wasm_error: WasmEncodedError = error.into();
                     Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED).unwrap();
-                    Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                    Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                 }
             };
             obj.into()
@@ -577,8 +585,9 @@ mod tests {
                     Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED).unwrap();
                 }
                 Err(error) => {
+                    let wasm_error: WasmEncodedError = error.into();
                     Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED).unwrap();
-                    Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                    Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
                 }
             };
             obj.into()

--- a/macros/tests/happy/func.test.expanded.rs
+++ b/macros/tests/happy/func.test.expanded.rs
@@ -42,9 +42,10 @@ pub async fn some_fn_preserve_class_async__wasm_export(arg: String) -> JsValue {
                 .unwrap();
         }
         Err(error) => {
+            let wasm_error: WasmEncodedError = error.into();
             Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
                 .unwrap();
-            Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+            Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
         }
     };
     obj.into()
@@ -68,9 +69,10 @@ pub fn some_fn_preserve_class_sync__wasm_export(arg: String) -> JsValue {
                 .unwrap();
         }
         Err(error) => {
+            let wasm_error: WasmEncodedError = error.into();
             Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
                 .unwrap();
-            Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+            Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
         }
     };
     obj.into()

--- a/macros/tests/happy/impl.test.expanded.rs
+++ b/macros/tests/happy/impl.test.expanded.rs
@@ -67,9 +67,11 @@ impl TestStruct {
                     .unwrap();
             }
             Err(error) => {
+                let wasm_error: WasmEncodedError = error.into();
                 Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
                     .unwrap();
-                Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into())
+                    .unwrap();
             }
         };
         obj.into()
@@ -90,9 +92,11 @@ impl TestStruct {
                     .unwrap();
             }
             Err(error) => {
+                let wasm_error: WasmEncodedError = error.into();
                 Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
                     .unwrap();
-                Reflect::set(&obj, &JsValue::from_str("error"), &error.into()).unwrap();
+                Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into())
+                    .unwrap();
             }
         };
         obj.into()


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The new `preserve_js_class` attribute returns an error but it's not compatible with the `WasmEncodedError`. Because of this the tests break in orderbook repo. We need to return an error with two fields `msg` and `readable_msg`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Cast the error into `WasmEncodedResult` before returning

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for exported functions and methods by standardizing error conversion, resulting in more consistent error information when interacting with JavaScript.
- **Tests**
  - Updated test cases to reflect the new error handling approach, ensuring accurate simulation of exported function and method behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->