### PR TITLE
(chore) Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Provides utilities and helpers that make working with wasm-bindge
 edition = "2021"
 license = "LicenseRef-DCL-1.0"
 version = "0.0.10"
-homepage = "https://github.com/rainlanguage/rain.wasm"
+repository = "https://github.com/rainlanguage/rain.wasm"
 
 [dependencies]
 paste = { version = "1.0" }


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project metadata to include a repository link instead of a homepage link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->