### PR TITLE
Add return description and param description attributes for js doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target
 Cargo.lock
 cache
+CLAUDE.md
+.ai_docs
+.ai_spec
+.claude

--- a/macros/src/wasm_export/attrs.rs
+++ b/macros/src/wasm_export/attrs.rs
@@ -512,7 +512,8 @@ mod tests {
     #[test]
     fn test_return_description_parsing() {
         // Test basic return_description parsing
-        let input = TokenStream::from_str(r#"return_description = "returns the sum of inputs""#).unwrap();
+        let input =
+            TokenStream::from_str(r#"return_description = "returns the sum of inputs""#).unwrap();
         let seq = Punctuated::<Meta, Token![,]>::parse_terminated
             .parse2(input)
             .unwrap();
@@ -527,7 +528,8 @@ mod tests {
         // Test duplicate return_description error
         let input = TokenStream::from_str(
             r#"return_description = "first desc", return_description = "second desc""#,
-        ).unwrap();
+        )
+        .unwrap();
         let seq = Punctuated::<Meta, Token![,]>::parse_terminated
             .parse2(input)
             .unwrap();
@@ -562,7 +564,10 @@ mod tests {
             should_skip: None,
             unchecked_return_type: None,
             preserve_js_class: None,
-            return_description: Some(("returns the calculated result".to_string(), Span::call_site())),
+            return_description: Some((
+                "returns the calculated result".to_string(),
+                Span::call_site(),
+            )),
         };
         let result = wasm_export_attrs.handle_return_type(&ret_type).unwrap();
 
@@ -585,13 +590,14 @@ mod tests {
         // Test return_description mixed with other attributes
         let input = TokenStream::from_str(
             r#"js_name = "customName", return_description = "custom description", catch"#,
-        ).unwrap();
+        )
+        .unwrap();
         let seq = Punctuated::<Meta, Token![,]>::parse_terminated
             .parse2(input)
             .unwrap();
         let mut wasm_export_attrs = WasmExportAttrs::default();
         wasm_export_attrs.handle_attrs_sequence(seq).unwrap();
-        
+
         assert!(wasm_export_attrs.return_description.is_some());
         assert_eq!(
             wasm_export_attrs.return_description.unwrap().0,

--- a/macros/src/wasm_export/builder.rs
+++ b/macros/src/wasm_export/builder.rs
@@ -13,8 +13,11 @@ pub enum SelfReceiver {
 }
 
 /// Type alias for the complex return type of process_function_parameters
-type ProcessFunctionParametersResult =
-    syn::Result<(SelfReceiver, Punctuated<FnArg, Comma>, Punctuated<FnArg, Comma>)>;
+type ProcessFunctionParametersResult = syn::Result<(
+    SelfReceiver,
+    Punctuated<FnArg, Comma>,
+    Punctuated<FnArg, Comma>,
+)>;
 
 /// Enum to specify the type of the function
 pub enum FunctionType<'a> {
@@ -153,8 +156,7 @@ impl WasmExportFunctionBuilder {
         let (call_expr, is_async) = match function_type {
             FunctionType::Method(method) => {
                 let fn_name = &method.sig.ident;
-                let (self_receiver, args) =
-                    Self::collect_function_arguments(&method.sig.inputs);
+                let (self_receiver, args) = Self::collect_function_arguments(&method.sig.inputs);
 
                 let call_expr = match self_receiver {
                     SelfReceiver::Instance => {
@@ -811,7 +813,10 @@ mod tests {
             .parse2(stream)
             .unwrap();
         let result = WasmExportFunctionBuilder::collect_function_arguments(&inputs);
-        let expected = (SelfReceiver::Instance, vec![TokenStream::from_str(r#"arg1"#).unwrap()]);
+        let expected = (
+            SelfReceiver::Instance,
+            vec![TokenStream::from_str(r#"arg1"#).unwrap()],
+        );
         assert_eq!(result.0, expected.0);
         assert_eq!(result.1.len(), expected.1.len());
         assert!(result

--- a/macros/src/wasm_export/impl_block.rs
+++ b/macros/src/wasm_export/impl_block.rs
@@ -56,7 +56,10 @@ pub fn parse(impl_block: &mut ItemImpl, top_attrs: WasmExportAttrs) -> Result<To
                         preserve_js_class,
                     };
                     let export_method =
-                        WasmExportFunctionBuilder::build_export_method(method, config);
+                        WasmExportFunctionBuilder::build_export_method(method, config)?;
+
+                    // Clean wasm_export attributes from original method parameters
+                    WasmExportFunctionBuilder::clean_parameter_attributes(&mut method.sig.inputs);
 
                     export_items.push(ImplItem::Fn(export_method));
                 } else {

--- a/macros/src/wasm_export/impl_block.rs
+++ b/macros/src/wasm_export/impl_block.rs
@@ -18,6 +18,12 @@ pub fn parse(impl_block: &mut ItemImpl, top_attrs: WasmExportAttrs) -> Result<To
             "unexpected `preserve_js_class` attribute, it can only be used for impl block methods or standalone functions",
         ));
     }
+    if let Some((_, span)) = top_attrs.return_description {
+        return Err(Error::new(
+            span,
+            "unexpected `return_description` attribute, it can only be used for impl block methods or standalone functions",
+        ));
+    }
 
     // create vector to store exported items
     // and loop over items inside of the impl block and process each method

--- a/macros/src/wasm_export/standalone_fn.rs
+++ b/macros/src/wasm_export/standalone_fn.rs
@@ -46,7 +46,10 @@ pub fn parse(func: &mut ItemFn, mut top_attrs: WasmExportAttrs) -> Result<TokenS
         return_type,
         preserve_js_class,
     };
-    let export_fn = WasmExportFunctionBuilder::build_export_function(func, config);
+    let export_fn = WasmExportFunctionBuilder::build_export_function(func, config)?;
+
+    // Clean wasm_export attributes from original function parameters
+    WasmExportFunctionBuilder::clean_parameter_attributes(&mut func.sig.inputs);
 
     // Combine original and exported function tokens
     let output = quote! {

--- a/macros/src/wasm_export/standalone_fn.rs
+++ b/macros/src/wasm_export/standalone_fn.rs
@@ -208,7 +208,8 @@ mod tests {
                 Ok(a + b)
             }
         );
-        let top_attrs: WasmExportAttrs = syn::parse_quote!(return_description = "sum of the inputs");
+        let top_attrs: WasmExportAttrs =
+            syn::parse_quote!(return_description = "sum of the inputs");
         let result = parse(&mut func, top_attrs).unwrap();
 
         let expected: TokenStream = parse_quote!(
@@ -236,8 +237,8 @@ mod tests {
             }
         );
         let top_attrs: WasmExportAttrs = syn::parse_quote!(
-            js_name = "complexCalculation", 
-            return_description = "complex calculation result", 
+            js_name = "complexCalculation",
+            return_description = "complex calculation result",
             catch
         );
         let result = parse(&mut func, top_attrs).unwrap();

--- a/macros/tests/happy/doc_comments_impl.test.expanded.rs
+++ b/macros/tests/happy/doc_comments_impl.test.expanded.rs
@@ -1,0 +1,117 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+struct Calculator {
+    value: u32,
+}
+impl Calculator {
+    /// Creates a new Calculator with the given initial value
+    ///
+    /// # Arguments
+    /// * `initial` - The starting value for the calculator
+    pub fn new(initial: u32) -> Result<Calculator, Error> {
+        Ok(Calculator { value: initial })
+    }
+    /// Adds a value to the current calculator value
+    /// Returns a new Calculator instance with the updated value
+    pub fn add(&self, other: u32) -> Result<Calculator, Error> {
+        Ok(Calculator {
+            value: self.value + other,
+        })
+    }
+    /// Gets the current value of the calculator
+    ///
+    /// This method returns the internal value as a u32.
+    /// The value represents the current state of the calculator.
+    pub fn get_value(&self) -> Result<u32, Error> {
+        Ok(self.value)
+    }
+    /// Complex calculation method with detailed documentation
+    ///
+    /// This method performs a complex calculation involving:
+    /// - Multiplication by the input factor
+    /// - Addition of a constant offset
+    /// - Modulo operation for bounds checking
+    ///
+    /// # Arguments
+    /// * `factor` - The multiplication factor
+    /// * `offset` - The offset to add
+    ///
+    /// # Returns
+    /// The result of the complex calculation
+    pub fn complex_calc(&self, factor: u32, offset: u32) -> Result<u32, Error> {
+        Ok(((self.value * factor) + offset) % 1000)
+    }
+}
+#[wasm_bindgen]
+impl Calculator {
+    /// Creates a new Calculator with the given initial value
+    ///
+    /// # Arguments
+    /// * `initial` - The starting value for the calculator
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<Calculator>")]
+    pub fn new__wasm_export(initial: u32) -> WasmEncodedResult<Calculator> {
+        Self::new(initial).into()
+    }
+    /// Adds a value to the current calculator value
+    /// Returns a new Calculator instance with the updated value
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<Calculator>")]
+    pub fn add__wasm_export(&self, other: u32) -> JsValue {
+        use js_sys::{Reflect, Object};
+        let obj = Object::new();
+        let result = self.add(other).into();
+        match result {
+            Ok(value) => {
+                Reflect::set(&obj, &JsValue::from_str("value"), &value.into()).unwrap();
+                Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED)
+                    .unwrap();
+            }
+            Err(error) => {
+                let wasm_error: WasmEncodedError = error.into();
+                Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
+                    .unwrap();
+                Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into())
+                    .unwrap();
+            }
+        };
+        obj.into()
+    }
+    /// Gets the current value of the calculator
+    ///
+    /// This method returns the internal value as a u32.
+    /// The value represents the current state of the calculator.
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(
+        js_name = "getValue",
+        unchecked_return_type = "WasmEncodedResult<u32>"
+    )]
+    pub fn get_value__wasm_export(&self) -> WasmEncodedResult<u32> {
+        self.get_value().into()
+    }
+    /// Complex calculation method with detailed documentation
+    ///
+    /// This method performs a complex calculation involving:
+    /// - Multiplication by the input factor
+    /// - Addition of a constant offset
+    /// - Modulo operation for bounds checking
+    ///
+    /// # Arguments
+    /// * `factor` - The multiplication factor
+    /// * `offset` - The offset to add
+    ///
+    /// # Returns
+    /// The result of the complex calculation
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(
+        unchecked_return_type = "WasmEncodedResult<u32>",
+        return_description = "result of complex calculation"
+    )]
+    pub fn complex_calc__wasm_export(
+        &self,
+        factor: u32,
+        offset: u32,
+    ) -> WasmEncodedResult<u32> {
+        self.complex_calc(factor, offset).into()
+    }
+}

--- a/macros/tests/happy/doc_comments_impl.test.rs
+++ b/macros/tests/happy/doc_comments_impl.test.rs
@@ -1,0 +1,52 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct Calculator {
+    value: u32,
+}
+
+#[wasm_export]
+impl Calculator {
+    /// Creates a new Calculator with the given initial value
+    /// 
+    /// # Arguments
+    /// * `initial` - The starting value for the calculator
+    #[wasm_export]
+    pub fn new(initial: u32) -> Result<Calculator, Error> {
+        Ok(Calculator { value: initial })
+    }
+
+    /// Adds a value to the current calculator value
+    /// Returns a new Calculator instance with the updated value
+    #[wasm_export(preserve_js_class)]
+    pub fn add(&self, other: u32) -> Result<Calculator, Error> {
+        Ok(Calculator { value: self.value + other })
+    }
+
+    /// Gets the current value of the calculator
+    /// 
+    /// This method returns the internal value as a u32.
+    /// The value represents the current state of the calculator.
+    #[wasm_export(js_name = "getValue")]
+    pub fn get_value(&self) -> Result<u32, Error> {
+        Ok(self.value)
+    }
+
+    /// Complex calculation method with detailed documentation
+    /// 
+    /// This method performs a complex calculation involving:
+    /// - Multiplication by the input factor
+    /// - Addition of a constant offset
+    /// - Modulo operation for bounds checking
+    /// 
+    /// # Arguments
+    /// * `factor` - The multiplication factor
+    /// * `offset` - The offset to add
+    /// 
+    /// # Returns
+    /// The result of the complex calculation
+    #[wasm_export(return_description = "result of complex calculation")]
+    pub fn complex_calc(&self, factor: u32, offset: u32) -> Result<u32, Error> {
+        Ok(((self.value * factor) + offset) % 1000)
+    }
+}

--- a/macros/tests/happy/doc_comments_standalone.test.expanded.rs
+++ b/macros/tests/happy/doc_comments_standalone.test.expanded.rs
@@ -1,0 +1,88 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+struct TestStruct;
+/// This function calculates the sum of two numbers
+/// It's a simple addition operation
+pub fn add(a: u32, b: u32) -> Result<u32, Error> {
+    Ok(a + b)
+}
+/// This function calculates the sum of two numbers
+/// It's a simple addition operation
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<u32>")]
+pub fn add__wasm_export(a: u32, b: u32) -> WasmEncodedResult<u32> {
+    add(a, b).into()
+}
+/// Multiply two numbers together
+///
+/// # Arguments
+/// * `x` - The first number
+/// * `y` - The second number
+///
+/// # Returns
+/// The product of x and y
+pub fn mul(x: u32, y: u32) -> Result<u32, Error> {
+    Ok(x * y)
+}
+/// Multiply two numbers together
+///
+/// # Arguments
+/// * `x` - The first number
+/// * `y` - The second number
+///
+/// # Returns
+/// The product of x and y
+#[allow(non_snake_case)]
+#[wasm_bindgen(js_name = "multiply", unchecked_return_type = "WasmEncodedResult<u32>")]
+pub fn mul__wasm_export(x: u32, y: u32) -> WasmEncodedResult<u32> {
+    mul(x, y).into()
+}
+/// Creates a new TestStruct instance
+///
+/// This is a more complex example with multiple
+/// lines of documentation that should be preserved
+/// in the generated wasm_bindgen function.
+pub fn create_test_struct() -> Result<TestStruct, Error> {
+    Ok(TestStruct)
+}
+/// Creates a new TestStruct instance
+///
+/// This is a more complex example with multiple
+/// lines of documentation that should be preserved
+/// in the generated wasm_bindgen function.
+#[allow(non_snake_case)]
+#[wasm_bindgen(
+    unchecked_return_type = "WasmEncodedResult<TestStruct>",
+    return_description = "new TestStruct instance"
+)]
+pub fn create_test_struct__wasm_export() -> WasmEncodedResult<TestStruct> {
+    create_test_struct().into()
+}
+/// Async function with doc comments
+/// This function demonstrates that doc comments work with async functions too
+pub async fn async_with_docs(input: String) -> Result<TestStruct, Error> {
+    Ok(TestStruct)
+}
+/// Async function with doc comments
+/// This function demonstrates that doc comments work with async functions too
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<TestStruct>")]
+pub async fn async_with_docs__wasm_export(input: String) -> JsValue {
+    use js_sys::{Reflect, Object};
+    let obj = Object::new();
+    let result = async_with_docs(input).await.into();
+    match result {
+        Ok(value) => {
+            Reflect::set(&obj, &JsValue::from_str("value"), &value.into()).unwrap();
+            Reflect::set(&obj, &JsValue::from_str("error"), &JsValue::UNDEFINED)
+                .unwrap();
+        }
+        Err(error) => {
+            let wasm_error: WasmEncodedError = error.into();
+            Reflect::set(&obj, &JsValue::from_str("value"), &JsValue::UNDEFINED)
+                .unwrap();
+            Reflect::set(&obj, &JsValue::from_str("error"), &wasm_error.into()).unwrap();
+        }
+    };
+    obj.into()
+}

--- a/macros/tests/happy/doc_comments_standalone.test.rs
+++ b/macros/tests/happy/doc_comments_standalone.test.rs
@@ -1,0 +1,41 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+/// This function calculates the sum of two numbers
+/// It's a simple addition operation
+#[wasm_export]
+pub fn add(a: u32, b: u32) -> Result<u32, Error> {
+    Ok(a + b)
+}
+
+/// Multiply two numbers together
+/// 
+/// # Arguments
+/// * `x` - The first number
+/// * `y` - The second number
+/// 
+/// # Returns
+/// The product of x and y
+#[wasm_export(js_name = "multiply")]
+pub fn mul(x: u32, y: u32) -> Result<u32, Error> {
+    Ok(x * y)
+}
+
+/// Creates a new TestStruct instance
+/// 
+/// This is a more complex example with multiple
+/// lines of documentation that should be preserved
+/// in the generated wasm_bindgen function.
+#[wasm_export(return_description = "new TestStruct instance")]
+pub fn create_test_struct() -> Result<TestStruct, Error> {
+    Ok(TestStruct)
+}
+
+/// Async function with doc comments
+/// This function demonstrates that doc comments work with async functions too
+#[wasm_export(preserve_js_class)]
+pub async fn async_with_docs(input: String) -> Result<TestStruct, Error> {
+    Ok(TestStruct)
+}

--- a/macros/tests/happy/func.test.expanded.rs
+++ b/macros/tests/happy/func.test.expanded.rs
@@ -103,3 +103,31 @@ pub async fn complex_calculation_with_desc__wasm_export(
 ) -> WasmEncodedResult<i64> {
     complex_calculation_with_desc(input).await.into()
 }
+pub fn add(arg1: u32, arg2: u32) -> Result<u32, Error> {
+    Ok(arg1 + arg2)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(
+    unchecked_return_type = "WasmEncodedResult<u32>",
+    return_description = "the result of the addition of `arg1` and `arg2`"
+)]
+pub fn add__wasm_export(
+    #[wasm_bindgen(param_description = "the first number")]
+    arg1: u32,
+    #[wasm_bindgen(param_description = "the second number")]
+    arg2: u32,
+) -> WasmEncodedResult<u32> {
+    add(arg1, arg2).into()
+}
+pub fn mixed_params(input: String, count: u32) -> Result<String, Error> {
+    Ok(input.repeat(count as usize))
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<String>")]
+pub fn mixed_params__wasm_export(
+    #[wasm_bindgen(param_description = "the input string")]
+    input: String,
+    count: u32,
+) -> WasmEncodedResult<String> {
+    mixed_params(input, count).into()
+}

--- a/macros/tests/happy/func.test.expanded.rs
+++ b/macros/tests/happy/func.test.expanded.rs
@@ -77,3 +77,29 @@ pub fn some_fn_preserve_class_sync__wasm_export(arg: String) -> JsValue {
     };
     obj.into()
 }
+pub fn add_with_description(a: u32, b: u32) -> Result<u32, Error> {
+    Ok(a + b)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(
+    unchecked_return_type = "WasmEncodedResult<u32>",
+    return_description = "returns the sum of two numbers"
+)]
+pub fn add_with_description__wasm_export(a: u32, b: u32) -> WasmEncodedResult<u32> {
+    add_with_description(a, b).into()
+}
+pub async fn complex_calculation_with_desc(input: String) -> Result<i64, Error> {
+    Ok(42)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(
+    js_name = "complexCalc",
+    catch,
+    unchecked_return_type = "WasmEncodedResult<i64>",
+    return_description = "performs complex calculation"
+)]
+pub async fn complex_calculation_with_desc__wasm_export(
+    input: String,
+) -> WasmEncodedResult<i64> {
+    complex_calculation_with_desc(input).await.into()
+}

--- a/macros/tests/happy/func.test.rs
+++ b/macros/tests/happy/func.test.rs
@@ -33,3 +33,22 @@ pub fn add_with_description(a: u32, b: u32) -> Result<u32, Error> {
 pub async fn complex_calculation_with_desc(input: String) -> Result<i64, Error> {
     Ok(42)
 }
+
+#[wasm_export(return_description = "the result of the addition of `arg1` and `arg2`")]
+pub fn add(
+    #[wasm_export(param_description = "the first number")]
+    arg1: u32,
+    #[wasm_export(param_description = "the second number")]
+    arg2: u32,
+) -> Result<u32, Error> {
+    Ok(arg1 + arg2)
+}
+
+#[wasm_export]
+pub fn mixed_params(
+    #[wasm_export(param_description = "the input string")]
+    input: String,
+    count: u32,  // no description
+) -> Result<String, Error> {
+    Ok(input.repeat(count as usize))
+}

--- a/macros/tests/happy/func.test.rs
+++ b/macros/tests/happy/func.test.rs
@@ -23,3 +23,13 @@ pub async fn some_fn_preserve_class_async(arg: String) -> Result<TestStruct, Err
 pub fn some_fn_preserve_class_sync(arg: String) -> Result<TestStruct, Error> {
     Ok(TestStruct)
 }
+
+#[wasm_export(return_description = "returns the sum of two numbers")]
+pub fn add_with_description(a: u32, b: u32) -> Result<u32, Error> {
+    Ok(a + b)
+}
+
+#[wasm_export(js_name = "complexCalc", return_description = "performs complex calculation", catch)]
+pub async fn complex_calculation_with_desc(input: String) -> Result<i64, Error> {
+    Ok(42)
+}

--- a/macros/tests/happy/impl.test.expanded.rs
+++ b/macros/tests/happy/impl.test.expanded.rs
@@ -112,6 +112,9 @@ impl TestStruct {
     pub fn get_age(&self, user_id: u32) -> Result<u32, Error> {
         Ok(25)
     }
+    pub fn number(&self, index: u32) -> Result<u32, Error> {
+        Ok(index * 2)
+    }
 }
 #[wasm_bindgen(some_top_wbg_attr = "something", some_other_wbg_attr)]
 impl TestStruct {
@@ -137,5 +140,17 @@ impl TestStruct {
     )]
     pub fn get_age__wasm_export(&self, user_id: u32) -> WasmEncodedResult<u32> {
         self.get_age(user_id).into()
+    }
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(
+        unchecked_return_type = "WasmEncodedResult<u32>",
+        return_description = "the number at the given index"
+    )]
+    pub fn number__wasm_export(
+        &self,
+        #[wasm_bindgen(param_description = "the index of the number to be returned")]
+        index: u32,
+    ) -> WasmEncodedResult<u32> {
+        self.number(index).into()
     }
 }

--- a/macros/tests/happy/impl.test.expanded.rs
+++ b/macros/tests/happy/impl.test.expanded.rs
@@ -106,6 +106,12 @@ impl TestStruct {
     pub fn returns_num_array(&mut self) -> Result<Vec<u8>, Error> {
         Ok(Vec::new())
     }
+    pub fn get_name(&self) -> Result<String, Error> {
+        Ok("test".to_string())
+    }
+    pub fn get_age(&self, user_id: u32) -> Result<u32, Error> {
+        Ok(25)
+    }
 }
 #[wasm_bindgen(some_top_wbg_attr = "something", some_other_wbg_attr)]
 impl TestStruct {
@@ -113,5 +119,23 @@ impl TestStruct {
     #[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<Vec < u8 >>")]
     pub fn returns_num_array__wasm_export(&mut self) -> WasmEncodedResult<Vec<u8>> {
         self.returns_num_array().into()
+    }
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(
+        unchecked_return_type = "WasmEncodedResult<String>",
+        return_description = "gets the user's name"
+    )]
+    pub fn get_name__wasm_export(&self) -> WasmEncodedResult<String> {
+        self.get_name().into()
+    }
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(
+        js_name = "getUserAge",
+        catch,
+        unchecked_return_type = "WasmEncodedResult<u32>",
+        return_description = "returns user age in years"
+    )]
+    pub fn get_age__wasm_export(&self, user_id: u32) -> WasmEncodedResult<u32> {
+        self.get_age(user_id).into()
     }
 }

--- a/macros/tests/happy/impl.test.rs
+++ b/macros/tests/happy/impl.test.rs
@@ -39,4 +39,14 @@ impl TestStruct {
     pub fn returns_num_array(&mut self) -> Result<Vec<u8>, Error> {
         Ok(Vec::new())
     }
+
+    #[wasm_export(return_description = "gets the user's name")]
+    pub fn get_name(&self) -> Result<String, Error> {
+        Ok("test".to_string())
+    }
+
+    #[wasm_export(js_name = "getUserAge", return_description = "returns user age in years", catch)]
+    pub fn get_age(&self, user_id: u32) -> Result<u32, Error> {
+        Ok(25)
+    }
 }

--- a/macros/tests/happy/impl.test.rs
+++ b/macros/tests/happy/impl.test.rs
@@ -49,4 +49,13 @@ impl TestStruct {
     pub fn get_age(&self, user_id: u32) -> Result<u32, Error> {
         Ok(25)
     }
+
+    #[wasm_export(return_description = "the number at the given index")]
+    pub fn number(
+        &self,
+        #[wasm_export(param_description = "the index of the number to be returned")]
+        index: u32,
+    ) -> Result<u32, Error> {
+        Ok(index * 2)
+    }
 }

--- a/macros/tests/unhappy/dup_param_description_attr.test.rs
+++ b/macros/tests/unhappy/dup_param_description_attr.test.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(param_description = "first description", param_description = "second description")]
+        arg: String
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/dup_param_description_attr.test.stderr
+++ b/macros/tests/unhappy/dup_param_description_attr.test.stderr
@@ -1,0 +1,5 @@
+error: duplicate `param_description` attribute
+  --> tests/unhappy/dup_param_description_attr.test.rs:10:64
+   |
+10 |         #[wasm_export(param_description = "first description", param_description = "second description")]
+   |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/dup_return_description_attr.test.rs
+++ b/macros/tests/unhappy/dup_return_description_attr.test.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export(return_description = "first description", return_description = "second description")]
+    pub async fn some_method_with_dup_return_desc(arg: String) -> Result<String, Error> {
+        Ok(String::new())
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/dup_return_description_attr.test.stderr
+++ b/macros/tests/unhappy/dup_return_description_attr.test.stderr
@@ -1,0 +1,5 @@
+error: duplicate `return_description` attribute
+ --> tests/unhappy/dup_return_description_attr.test.rs:8:61
+  |
+8 |     #[wasm_export(return_description = "first description", return_description = "second description")]
+  |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/expected_param_description_str_literal.test.rs
+++ b/macros/tests/unhappy/expected_param_description_str_literal.test.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub fn test_method(
+        #[wasm_export(param_description = something)]
+        arg: String,
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+struct TestStruct;
+
+fn main() {}

--- a/macros/tests/unhappy/expected_param_description_str_literal.test.stderr
+++ b/macros/tests/unhappy/expected_param_description_str_literal.test.stderr
@@ -1,0 +1,5 @@
+error: expected string literal
+ --> tests/unhappy/expected_param_description_str_literal.test.rs:8:23
+  |
+8 |         #[wasm_export(param_description = something)]
+  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/expected_param_description_value.test.rs
+++ b/macros/tests/unhappy/expected_param_description_value.test.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+pub fn test_function(
+    #[wasm_export(param_description)]
+    arg: String,
+) -> Result<String, Error> {
+    Ok(arg)
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_param_description_value.test.stderr
+++ b/macros/tests/unhappy/expected_param_description_value.test.stderr
@@ -1,0 +1,5 @@
+error: expected a value for this attribute: `param_description = ...` and it must be a string literal
+ --> tests/unhappy/expected_param_description_value.test.rs:8:19
+  |
+8 |     #[wasm_export(param_description)]
+  |                   ^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/expected_return_description_str_literal.test.rs
+++ b/macros/tests/unhappy/expected_return_description_str_literal.test.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export(return_description = something)]
+    pub async fn some_method_with_invalid_return_desc(arg: String) -> Result<String, Error> {
+        Ok(String::new())
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_return_description_str_literal.test.stderr
+++ b/macros/tests/unhappy/expected_return_description_str_literal.test.stderr
@@ -1,0 +1,5 @@
+error: expected string literal
+ --> tests/unhappy/expected_return_description_str_literal.test.rs:8:19
+  |
+8 |     #[wasm_export(return_description = something)]
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/expected_return_description_value.test.rs
+++ b/macros/tests/unhappy/expected_return_description_value.test.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export(return_description)]
+    pub async fn some_method_missing_return_desc_value(arg: String) -> Result<String, Error> {
+        Ok(String::new())
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_return_description_value.test.stderr
+++ b/macros/tests/unhappy/expected_return_description_value.test.stderr
@@ -1,0 +1,5 @@
+error: expected a value for this attribute: `return_description = ...` and it must be a string literal
+ --> tests/unhappy/expected_return_description_value.test.rs:8:19
+  |
+8 |     #[wasm_export(return_description)]
+  |                   ^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/invalid_param_attrs_delimiter.test.rs
+++ b/macros/tests/unhappy/invalid_param_attrs_delimiter.test.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub fn test_method1(
+        #[wasm_export(param_description = "first"; param_description = "second")]
+        arg: String,
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+#[wasm_export] 
+impl TestStruct {
+    #[wasm_export]
+    pub fn test_method2(
+        #[wasm_export(param_description = "test" - something_else)]
+        arg: String,
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/invalid_param_attrs_delimiter.test.stderr
+++ b/macros/tests/unhappy/invalid_param_attrs_delimiter.test.stderr
@@ -1,0 +1,11 @@
+error: expected `,`
+  --> tests/unhappy/invalid_param_attrs_delimiter.test.rs:10:50
+   |
+10 |         #[wasm_export(param_description = "first"; param_description = "second")]
+   |                                                  ^
+
+error: expected string literal
+  --> tests/unhappy/invalid_param_attrs_delimiter.test.rs:21:23
+   |
+21 |         #[wasm_export(param_description = "test" - something_else)]
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/param_description_on_self.test.rs
+++ b/macros/tests/unhappy/param_description_on_self.test.rs
@@ -1,0 +1,18 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub fn test_method(
+        #[wasm_export(param_description = "the instance")]
+        &self,
+        arg: String,
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/param_description_on_self.test.stderr
+++ b/macros/tests/unhappy/param_description_on_self.test.stderr
@@ -1,0 +1,5 @@
+error: `param_description` cannot be used on receiver parameters (self, &self, &mut self)
+  --> tests/unhappy/param_description_on_self.test.rs:10:9
+   |
+10 |         #[wasm_export(param_description = "the instance")]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/unexpected_return_description_attr.test.rs
+++ b/macros/tests/unhappy/unexpected_return_description_attr.test.rs
@@ -1,0 +1,13 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export(return_description = "unexpected description")]
+impl TestStruct {
+    pub async fn some_method(arg: String) -> Result<String, Error> {
+        Ok(String::new())
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/unexpected_return_description_attr.test.stderr
+++ b/macros/tests/unhappy/unexpected_return_description_attr.test.stderr
@@ -1,0 +1,5 @@
+error: unexpected `return_description` attribute, it can only be used for impl block methods or standalone functions
+ --> tests/unhappy/unexpected_return_description_attr.test.rs:6:15
+  |
+6 | #[wasm_export(return_description = "unexpected description")]
+  |               ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: https://github.com/rainlanguage/rain.wasm/issues/32

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add `return_description`, `param_description` and doc comment forwarding
- Update tests

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.wasm/issues/32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `return_description` and `param_description` attributes in WebAssembly exports, enabling detailed documentation and metadata in generated bindings.
  - Forwarded parameter and return descriptions to JavaScript bindings for improved clarity.
  - Preserved Rust doc comments in wasm export wrappers, including support for async functions and JS interop attributes.
  - Enhanced exported functions and methods with customizable JS names, error catching, and return type handling.

- **Bug Fixes**
  - Improved error handling for duplicate, missing, or malformed `param_description` and `return_description` attributes with precise compiler diagnostics.
  - Enforced attribute usage rules, disallowing `param_description` on receiver parameters and `return_description` on unsupported items.
  - Added validation to reject invalid attribute delimiters and non-string literal values.

- **Tests**
  - Added extensive tests covering attribute parsing, forwarding, error cases, doc comment preservation, async function exports, and parameter-level metadata.

- **Chores**
  - Updated `.gitignore` to exclude new AI-related files and directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->