### PR TITLE
Add new function parameter attributes to wasm export macro

### DIFF
--- a/macros/src/wasm_export/attrs.rs
+++ b/macros/src/wasm_export/attrs.rs
@@ -19,6 +19,7 @@ impl AttrKeys {
     pub const PRESERVE_JS_CLASS: &'static str = "preserve_js_class";
     pub const UNCHECKED_RETURN_TYPE: &'static str = "unchecked_return_type";
     pub const RETURN_DESCRIPTION: &'static str = "return_description";
+    pub const UNCHECKED_PARAM_TYPE: &'static str = "unchecked_param_type";
 }
 
 /// Struct that holds the parsed wasm_export attributes details

--- a/macros/src/wasm_export/attrs.rs
+++ b/macros/src/wasm_export/attrs.rs
@@ -20,6 +20,7 @@ impl AttrKeys {
     pub const UNCHECKED_RETURN_TYPE: &'static str = "unchecked_return_type";
     pub const RETURN_DESCRIPTION: &'static str = "return_description";
     pub const UNCHECKED_PARAM_TYPE: &'static str = "unchecked_param_type";
+    pub const JS_NAME: &'static str = "js_name";
 }
 
 /// Struct that holds the parsed wasm_export attributes details

--- a/macros/src/wasm_export/builder.rs
+++ b/macros/src/wasm_export/builder.rs
@@ -334,6 +334,7 @@ impl WasmExportFunctionBuilder {
         let mut wasm_bindgen_metas = Vec::new();
         let mut seen_param_description = false;
         let mut seen_unchecked_param_type = false;
+        let mut seen_js_name = false;
 
         // Handle empty wasm_export attribute
         if matches!(attr.meta, Meta::Path(_)) {
@@ -345,56 +346,86 @@ impl WasmExportFunctionBuilder {
 
         for meta in nested_metas {
             if let Some(ident) = meta.path().get_ident() {
-                if ident == "param_description" {
-                    // Check for duplicate param_description
-                    if seen_param_description {
-                        return Err(syn::Error::new_spanned(
-                            meta,
-                            "duplicate `param_description` attribute",
-                        ));
-                    }
-                    seen_param_description = true;
+                match ident.to_string().as_str() {
+                    "param_description" => {
+                        // Check for duplicate param_description
+                        if seen_param_description {
+                            return Err(syn::Error::new_spanned(
+                                meta,
+                                "duplicate `param_description` attribute",
+                            ));
+                        }
+                        seen_param_description = true;
 
-                    // Validate that it has a string literal value
-                    if let syn::Expr::Lit(syn::ExprLit {
-                        lit: syn::Lit::Str(_),
-                        ..
-                    }) = &meta
-                        .require_name_value()
-                        .map_err(extend_err_msg(" and it must be a string literal"))?
-                        .value
-                    {
-                        // Convert param_description from wasm_export to wasm_bindgen format
-                        wasm_bindgen_metas.push(meta);
-                    } else {
-                        return Err(syn::Error::new_spanned(meta, "expected string literal"));
+                        // Validate that it has a string literal value
+                        if let syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Str(_),
+                            ..
+                        }) = &meta
+                            .require_name_value()
+                            .map_err(extend_err_msg(" and it must be a string literal"))?
+                            .value
+                        {
+                            // Convert param_description from wasm_export to wasm_bindgen format
+                            wasm_bindgen_metas.push(meta);
+                        } else {
+                            return Err(syn::Error::new_spanned(meta, "expected string literal"));
+                        }
                     }
-                } else if ident == AttrKeys::UNCHECKED_PARAM_TYPE {
-                    // Check for duplicate unchecked_param_type
-                    if seen_unchecked_param_type {
-                        return Err(syn::Error::new_spanned(
-                            meta,
-                            "duplicate `unchecked_param_type` attribute",
-                        ));
-                    }
-                    seen_unchecked_param_type = true;
+                    AttrKeys::UNCHECKED_PARAM_TYPE => {
+                        // Check for duplicate unchecked_param_type
+                        if seen_unchecked_param_type {
+                            return Err(syn::Error::new_spanned(
+                                meta,
+                                "duplicate `unchecked_param_type` attribute",
+                            ));
+                        }
+                        seen_unchecked_param_type = true;
 
-                    // Validate that it has a string literal value
-                    if let syn::Expr::Lit(syn::ExprLit {
-                        lit: syn::Lit::Str(_),
-                        ..
-                    }) = &meta
-                        .require_name_value()
-                        .map_err(extend_err_msg(" and it must be a string literal"))?
-                        .value
-                    {
-                        // Convert unchecked_param_type from wasm_export to wasm_bindgen format
-                        wasm_bindgen_metas.push(meta);
-                    } else {
-                        return Err(syn::Error::new_spanned(meta, "expected string literal"));
+                        // Validate that it has a string literal value
+                        if let syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Str(_),
+                            ..
+                        }) = &meta
+                            .require_name_value()
+                            .map_err(extend_err_msg(" and it must be a string literal"))?
+                            .value
+                        {
+                            // Convert unchecked_param_type from wasm_export to wasm_bindgen format
+                            wasm_bindgen_metas.push(meta);
+                        } else {
+                            return Err(syn::Error::new_spanned(meta, "expected string literal"));
+                        }
+                    }
+                    AttrKeys::JS_NAME => {
+                        // Check for duplicate js_name
+                        if seen_js_name {
+                            return Err(syn::Error::new_spanned(
+                                meta,
+                                "duplicate `js_name` attribute",
+                            ));
+                        }
+                        seen_js_name = true;
+
+                        // Validate that it has a string literal value
+                        if let syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Str(_),
+                            ..
+                        }) = &meta
+                            .require_name_value()
+                            .map_err(extend_err_msg(" and it must be a string literal"))?
+                            .value
+                        {
+                            // Convert js_name from wasm_export to wasm_bindgen format
+                            wasm_bindgen_metas.push(meta);
+                        } else {
+                            return Err(syn::Error::new_spanned(meta, "expected string literal"));
+                        }
+                    }
+                    _ => {
+                        // Unknown attributes are ignored (could be forwarded in the future)
                     }
                 }
-                // Add support for other parameter-level attributes here if needed
             }
         }
 

--- a/macros/src/wasm_export/builder.rs
+++ b/macros/src/wasm_export/builder.rs
@@ -279,7 +279,7 @@ impl WasmExportFunctionBuilder {
                         if attr.path().is_ident("wasm_export") {
                             return Err(syn::Error::new_spanned(
                                 attr,
-                                "`param_description` cannot be used on receiver parameters (self, &self, &mut self)"
+                                "wasm_export parameter attributes cannot be used on receiver parameters (self, &self, &mut self)"
                             ));
                         }
                     }
@@ -979,7 +979,7 @@ mod tests {
         let error = result.unwrap_err();
         assert!(error
             .to_string()
-            .contains("param_description` cannot be used on receiver parameters"));
+            .contains("wasm_export parameter attributes cannot be used on receiver parameters"));
     }
 
     #[test]

--- a/macros/tests/happy/func.test.expanded.rs
+++ b/macros/tests/happy/func.test.expanded.rs
@@ -179,3 +179,69 @@ pub fn with_unchecked_and_js_name__wasm_export(
 ) -> WasmEncodedResult<u32> {
     with_unchecked_and_js_name(element).into()
 }
+pub fn with_js_name_params(
+    first_name: String,
+    last_name: String,
+) -> Result<String, Error> {
+    Ok({
+        let res = ::alloc::fmt::format(format_args!("{0} {1}", first_name, last_name));
+        res
+    })
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<String>")]
+pub fn with_js_name_params__wasm_export(
+    #[wasm_bindgen(js_name = "firstName")]
+    first_name: String,
+    #[wasm_bindgen(js_name = "lastName")]
+    last_name: String,
+) -> WasmEncodedResult<String> {
+    with_js_name_params(first_name, last_name).into()
+}
+pub fn with_mixed_js_attributes(
+    user_data: wasm_bindgen::JsValue,
+    process_mode: String,
+) -> Result<bool, Error> {
+    Ok(true)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(
+    js_name = "processUserData",
+    unchecked_return_type = "WasmEncodedResult<bool>"
+)]
+pub fn with_mixed_js_attributes__wasm_export(
+    #[wasm_bindgen(
+        js_name = "userData",
+        param_description = "the user's data object",
+        unchecked_param_type = "UserData"
+    )]
+    user_data: wasm_bindgen::JsValue,
+    #[wasm_bindgen(js_name = "processMode")]
+    process_mode: String,
+) -> WasmEncodedResult<bool> {
+    with_mixed_js_attributes(user_data, process_mode).into()
+}
+pub fn snake_to_camel_conversion(
+    user_id: u32,
+    is_active: bool,
+    created_at: String,
+) -> Result<String, Error> {
+    Ok({
+        let res = ::alloc::fmt::format(
+            format_args!("User {0} active: {1} at {2}", user_id, is_active, created_at),
+        );
+        res
+    })
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<String>")]
+pub fn snake_to_camel_conversion__wasm_export(
+    #[wasm_bindgen(js_name = "userId")]
+    user_id: u32,
+    #[wasm_bindgen(js_name = "isActive")]
+    is_active: bool,
+    #[wasm_bindgen(js_name = "createdAt")]
+    created_at: String,
+) -> WasmEncodedResult<String> {
+    snake_to_camel_conversion(user_id, is_active, created_at).into()
+}

--- a/macros/tests/happy/func.test.expanded.rs
+++ b/macros/tests/happy/func.test.expanded.rs
@@ -131,3 +131,51 @@ pub fn mixed_params__wasm_export(
 ) -> WasmEncodedResult<String> {
     mixed_params(input, count).into()
 }
+pub fn with_unchecked_param_type(
+    custom_param: wasm_bindgen::JsValue,
+    normal_param: String,
+) -> Result<String, Error> {
+    Ok(normal_param)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<String>")]
+pub fn with_unchecked_param_type__wasm_export(
+    #[wasm_bindgen(unchecked_param_type = "CustomJSType")]
+    custom_param: wasm_bindgen::JsValue,
+    normal_param: String,
+) -> WasmEncodedResult<String> {
+    with_unchecked_param_type(custom_param, normal_param).into()
+}
+pub fn with_mixed_param_attrs(
+    mixed_param: wasm_bindgen::JsValue,
+    regular_param: String,
+) -> Result<String, Error> {
+    Ok(regular_param)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<String>")]
+pub fn with_mixed_param_attrs__wasm_export(
+    #[wasm_bindgen(
+        param_description = "a custom JS object",
+        unchecked_param_type = "MyCustomType"
+    )]
+    mixed_param: wasm_bindgen::JsValue,
+    #[wasm_bindgen(param_description = "a regular string")]
+    regular_param: String,
+) -> WasmEncodedResult<String> {
+    with_mixed_param_attrs(mixed_param, regular_param).into()
+}
+pub fn with_unchecked_and_js_name(element: wasm_bindgen::JsValue) -> Result<u32, Error> {
+    Ok(42)
+}
+#[allow(non_snake_case)]
+#[wasm_bindgen(
+    js_name = "customFunction",
+    unchecked_return_type = "WasmEncodedResult<u32>"
+)]
+pub fn with_unchecked_and_js_name__wasm_export(
+    #[wasm_bindgen(unchecked_param_type = "HTMLElement")]
+    element: wasm_bindgen::JsValue,
+) -> WasmEncodedResult<u32> {
+    with_unchecked_and_js_name(element).into()
+}

--- a/macros/tests/happy/func.test.rs
+++ b/macros/tests/happy/func.test.rs
@@ -52,3 +52,30 @@ pub fn mixed_params(
 ) -> Result<String, Error> {
     Ok(input.repeat(count as usize))
 }
+
+#[wasm_export]
+pub fn with_unchecked_param_type(
+    #[wasm_export(unchecked_param_type = "CustomJSType")]
+    custom_param: wasm_bindgen::JsValue,
+    normal_param: String,
+) -> Result<String, Error> {
+    Ok(normal_param)
+}
+
+#[wasm_export]
+pub fn with_mixed_param_attrs(
+    #[wasm_export(param_description = "a custom JS object", unchecked_param_type = "MyCustomType")]
+    mixed_param: wasm_bindgen::JsValue,
+    #[wasm_export(param_description = "a regular string")]
+    regular_param: String,
+) -> Result<String, Error> {
+    Ok(regular_param)
+}
+
+#[wasm_export(js_name = "customFunction")]
+pub fn with_unchecked_and_js_name(
+    #[wasm_export(unchecked_param_type = "HTMLElement")]
+    element: wasm_bindgen::JsValue,
+) -> Result<u32, Error> {
+    Ok(42)
+}

--- a/macros/tests/happy/func.test.rs
+++ b/macros/tests/happy/func.test.rs
@@ -79,3 +79,35 @@ pub fn with_unchecked_and_js_name(
 ) -> Result<u32, Error> {
     Ok(42)
 }
+
+#[wasm_export]
+pub fn with_js_name_params(
+    #[wasm_export(js_name = "firstName")]
+    first_name: String,
+    #[wasm_export(js_name = "lastName")]
+    last_name: String,
+) -> Result<String, Error> {
+    Ok(format!("{} {}", first_name, last_name))
+}
+
+#[wasm_export(js_name = "processUserData")]
+pub fn with_mixed_js_attributes(
+    #[wasm_export(js_name = "userData", param_description = "the user's data object", unchecked_param_type = "UserData")]
+    user_data: wasm_bindgen::JsValue,
+    #[wasm_export(js_name = "processMode")]
+    process_mode: String,
+) -> Result<bool, Error> {
+    Ok(true)
+}
+
+#[wasm_export]
+pub fn snake_to_camel_conversion(
+    #[wasm_export(js_name = "userId")]
+    user_id: u32,
+    #[wasm_export(js_name = "isActive")]
+    is_active: bool,
+    #[wasm_export(js_name = "createdAt")]
+    created_at: String,
+) -> Result<String, Error> {
+    Ok(format!("User {} active: {} at {}", user_id, is_active, created_at))
+}

--- a/macros/tests/happy/impl.test.expanded.rs
+++ b/macros/tests/happy/impl.test.expanded.rs
@@ -115,6 +115,19 @@ impl TestStruct {
     pub fn number(&self, index: u32) -> Result<u32, Error> {
         Ok(index * 2)
     }
+    pub fn with_unchecked_param(
+        &self,
+        custom_param: wasm_bindgen::JsValue,
+    ) -> Result<String, Error> {
+        Ok("success".to_string())
+    }
+    pub fn process_element(
+        &mut self,
+        element: wasm_bindgen::JsValue,
+        options: String,
+    ) -> Result<bool, Error> {
+        Ok(true)
+    }
 }
 #[wasm_bindgen(some_top_wbg_attr = "something", some_other_wbg_attr)]
 impl TestStruct {
@@ -152,5 +165,31 @@ impl TestStruct {
         index: u32,
     ) -> WasmEncodedResult<u32> {
         self.number(index).into()
+    }
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<String>")]
+    pub fn with_unchecked_param__wasm_export(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "CustomJSType")]
+        custom_param: wasm_bindgen::JsValue,
+    ) -> WasmEncodedResult<String> {
+        self.with_unchecked_param(custom_param).into()
+    }
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(
+        js_name = "processElement",
+        unchecked_return_type = "WasmEncodedResult<bool>"
+    )]
+    pub fn process_element__wasm_export(
+        &mut self,
+        #[wasm_bindgen(
+            unchecked_param_type = "HTMLElement",
+            param_description = "the DOM element to process"
+        )]
+        element: wasm_bindgen::JsValue,
+        #[wasm_bindgen(param_description = "processing options")]
+        options: String,
+    ) -> WasmEncodedResult<bool> {
+        self.process_element(element, options).into()
     }
 }

--- a/macros/tests/happy/impl.test.expanded.rs
+++ b/macros/tests/happy/impl.test.expanded.rs
@@ -128,6 +128,26 @@ impl TestStruct {
     ) -> Result<bool, Error> {
         Ok(true)
     }
+    pub fn with_js_name_params(
+        &self,
+        primary_key: u32,
+        display_name: String,
+    ) -> Result<String, Error> {
+        Ok({
+            let res = ::alloc::fmt::format(
+                format_args!("Item {0}: {1}", primary_key, display_name),
+            );
+            res
+        })
+    }
+    pub fn update_record(
+        &mut self,
+        record_id: u32,
+        new_data: wasm_bindgen::JsValue,
+        save_options: String,
+    ) -> Result<bool, Error> {
+        Ok(true)
+    }
 }
 #[wasm_bindgen(some_top_wbg_attr = "something", some_other_wbg_attr)]
 impl TestStruct {
@@ -191,5 +211,38 @@ impl TestStruct {
         options: String,
     ) -> WasmEncodedResult<bool> {
         self.process_element(element, options).into()
+    }
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(unchecked_return_type = "WasmEncodedResult<String>")]
+    pub fn with_js_name_params__wasm_export(
+        &self,
+        #[wasm_bindgen(js_name = "primaryKey")]
+        primary_key: u32,
+        #[wasm_bindgen(js_name = "displayName")]
+        display_name: String,
+    ) -> WasmEncodedResult<String> {
+        self.with_js_name_params(primary_key, display_name).into()
+    }
+    #[allow(non_snake_case)]
+    #[wasm_bindgen(
+        js_name = "updateRecord",
+        unchecked_return_type = "WasmEncodedResult<bool>"
+    )]
+    pub fn update_record__wasm_export(
+        &mut self,
+        #[wasm_bindgen(
+            js_name = "recordId",
+            param_description = "unique identifier for the record"
+        )]
+        record_id: u32,
+        #[wasm_bindgen(js_name = "newData", unchecked_param_type = "RecordData")]
+        new_data: wasm_bindgen::JsValue,
+        #[wasm_bindgen(
+            js_name = "saveOptions",
+            param_description = "options for saving"
+        )]
+        save_options: String,
+    ) -> WasmEncodedResult<bool> {
+        self.update_record(record_id, new_data, save_options).into()
     }
 }

--- a/macros/tests/happy/impl.test.rs
+++ b/macros/tests/happy/impl.test.rs
@@ -78,4 +78,28 @@ impl TestStruct {
     ) -> Result<bool, Error> {
         Ok(true)
     }
+
+    #[wasm_export]
+    pub fn with_js_name_params(
+        &self,
+        #[wasm_export(js_name = "primaryKey")]
+        primary_key: u32,
+        #[wasm_export(js_name = "displayName")]
+        display_name: String,
+    ) -> Result<String, Error> {
+        Ok(format!("Item {}: {}", primary_key, display_name))
+    }
+
+    #[wasm_export(js_name = "updateRecord")]
+    pub fn update_record(
+        &mut self,
+        #[wasm_export(js_name = "recordId", param_description = "unique identifier for the record")]
+        record_id: u32,
+        #[wasm_export(js_name = "newData", unchecked_param_type = "RecordData")]
+        new_data: wasm_bindgen::JsValue,
+        #[wasm_export(js_name = "saveOptions", param_description = "options for saving")]
+        save_options: String,
+    ) -> Result<bool, Error> {
+        Ok(true)
+    }
 }

--- a/macros/tests/happy/impl.test.rs
+++ b/macros/tests/happy/impl.test.rs
@@ -58,4 +58,24 @@ impl TestStruct {
     ) -> Result<u32, Error> {
         Ok(index * 2)
     }
+
+    #[wasm_export]
+    pub fn with_unchecked_param(
+        &self,
+        #[wasm_export(unchecked_param_type = "CustomJSType")]
+        custom_param: wasm_bindgen::JsValue,
+    ) -> Result<String, Error> {
+        Ok("success".to_string())
+    }
+
+    #[wasm_export(js_name = "processElement")]
+    pub fn process_element(
+        &mut self,
+        #[wasm_export(unchecked_param_type = "HTMLElement", param_description = "the DOM element to process")]
+        element: wasm_bindgen::JsValue,
+        #[wasm_export(param_description = "processing options")]
+        options: String,
+    ) -> Result<bool, Error> {
+        Ok(true)
+    }
 }

--- a/macros/tests/unhappy/dup_js_name_param_attr.test.rs
+++ b/macros/tests/unhappy/dup_js_name_param_attr.test.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(js_name = "firstName", js_name = "secondName")]
+        arg: String
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/dup_js_name_param_attr.test.stderr
+++ b/macros/tests/unhappy/dup_js_name_param_attr.test.stderr
@@ -1,0 +1,5 @@
+error: duplicate `js_name` attribute
+  --> tests/unhappy/dup_js_name_param_attr.test.rs:10:46
+   |
+10 |         #[wasm_export(js_name = "firstName", js_name = "secondName")]
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/dup_unchecked_param_type_attr.test.rs
+++ b/macros/tests/unhappy/dup_unchecked_param_type_attr.test.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(unchecked_param_type = "FirstType", unchecked_param_type = "SecondType")]
+        arg: wasm_bindgen::JsValue
+    ) -> Result<String, Error> {
+        Ok("test".to_string())
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/dup_unchecked_param_type_attr.test.stderr
+++ b/macros/tests/unhappy/dup_unchecked_param_type_attr.test.stderr
@@ -1,0 +1,5 @@
+error: duplicate `unchecked_param_type` attribute
+  --> tests/unhappy/dup_unchecked_param_type_attr.test.rs:10:59
+   |
+10 |         #[wasm_export(unchecked_param_type = "FirstType", unchecked_param_type = "SecondType")]
+   |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/expected_js_name_param_str_literal.test.rs
+++ b/macros/tests/unhappy/expected_js_name_param_str_literal.test.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(js_name = notStringLiteral)]
+        arg: String
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_js_name_param_str_literal.test.stderr
+++ b/macros/tests/unhappy/expected_js_name_param_str_literal.test.stderr
@@ -1,0 +1,5 @@
+error: expected string literal
+  --> tests/unhappy/expected_js_name_param_str_literal.test.rs:10:23
+   |
+10 |         #[wasm_export(js_name = notStringLiteral)]
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/expected_js_name_param_value.test.rs
+++ b/macros/tests/unhappy/expected_js_name_param_value.test.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(js_name)]
+        arg: String
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_js_name_param_value.test.stderr
+++ b/macros/tests/unhappy/expected_js_name_param_value.test.stderr
@@ -1,0 +1,5 @@
+error: expected a value for this attribute: `js_name = ...` and it must be a string literal
+  --> tests/unhappy/expected_js_name_param_value.test.rs:10:23
+   |
+10 |         #[wasm_export(js_name)]
+   |                       ^^^^^^^

--- a/macros/tests/unhappy/expected_unchecked_param_type_str_literal.test.rs
+++ b/macros/tests/unhappy/expected_unchecked_param_type_str_literal.test.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(unchecked_param_type = notStringLiteral)]
+        arg: wasm_bindgen::JsValue
+    ) -> Result<String, Error> {
+        Ok("test".to_string())
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_unchecked_param_type_str_literal.test.stderr
+++ b/macros/tests/unhappy/expected_unchecked_param_type_str_literal.test.stderr
@@ -1,0 +1,5 @@
+error: expected string literal
+  --> tests/unhappy/expected_unchecked_param_type_str_literal.test.rs:10:23
+   |
+10 |         #[wasm_export(unchecked_param_type = notStringLiteral)]
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/expected_unchecked_param_type_value.test.rs
+++ b/macros/tests/unhappy/expected_unchecked_param_type_value.test.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(unchecked_param_type)]
+        arg: wasm_bindgen::JsValue
+    ) -> Result<String, Error> {
+        Ok("test".to_string())
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/expected_unchecked_param_type_value.test.stderr
+++ b/macros/tests/unhappy/expected_unchecked_param_type_value.test.stderr
@@ -1,0 +1,5 @@
+error: expected a value for this attribute: `unchecked_param_type = ...` and it must be a string literal
+  --> tests/unhappy/expected_unchecked_param_type_value.test.rs:10:23
+   |
+10 |         #[wasm_export(unchecked_param_type)]
+   |                       ^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/js_name_param_on_self.test.rs
+++ b/macros/tests/unhappy/js_name_param_on_self.test.rs
@@ -1,0 +1,18 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(js_name = "selfParam")]
+        &self,
+        arg: String
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/js_name_param_on_self.test.stderr
+++ b/macros/tests/unhappy/js_name_param_on_self.test.stderr
@@ -1,4 +1,4 @@
-error: `param_description` cannot be used on receiver parameters (self, &self, &mut self)
+error: wasm_export parameter attributes cannot be used on receiver parameters (self, &self, &mut self)
   --> tests/unhappy/js_name_param_on_self.test.rs:10:9
    |
 10 |         #[wasm_export(js_name = "selfParam")]

--- a/macros/tests/unhappy/js_name_param_on_self.test.stderr
+++ b/macros/tests/unhappy/js_name_param_on_self.test.stderr
@@ -1,0 +1,5 @@
+error: `param_description` cannot be used on receiver parameters (self, &self, &mut self)
+  --> tests/unhappy/js_name_param_on_self.test.rs:10:9
+   |
+10 |         #[wasm_export(js_name = "selfParam")]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/param_description_on_self.test.stderr
+++ b/macros/tests/unhappy/param_description_on_self.test.stderr
@@ -1,4 +1,4 @@
-error: `param_description` cannot be used on receiver parameters (self, &self, &mut self)
+error: wasm_export parameter attributes cannot be used on receiver parameters (self, &self, &mut self)
   --> tests/unhappy/param_description_on_self.test.rs:10:9
    |
 10 |         #[wasm_export(param_description = "the instance")]

--- a/macros/tests/unhappy/unchecked_param_type_on_self.test.rs
+++ b/macros/tests/unhappy/unchecked_param_type_on_self.test.rs
@@ -1,0 +1,18 @@
+#[macro_use]
+extern crate wasm_bindgen_utils_macros;
+
+struct TestStruct;
+
+#[wasm_export]
+impl TestStruct {
+    #[wasm_export]
+    pub async fn test_method(
+        #[wasm_export(unchecked_param_type = "CustomType")]
+        &self,
+        arg: String
+    ) -> Result<String, Error> {
+        Ok(arg)
+    }
+}
+
+fn main() {}

--- a/macros/tests/unhappy/unchecked_param_type_on_self.test.stderr
+++ b/macros/tests/unhappy/unchecked_param_type_on_self.test.stderr
@@ -1,0 +1,5 @@
+error: `param_description` cannot be used on receiver parameters (self, &self, &mut self)
+  --> tests/unhappy/unchecked_param_type_on_self.test.rs:10:9
+   |
+10 |         #[wasm_export(unchecked_param_type = "CustomType")]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/macros/tests/unhappy/unchecked_param_type_on_self.test.stderr
+++ b/macros/tests/unhappy/unchecked_param_type_on_self.test.stderr
@@ -1,4 +1,4 @@
-error: `param_description` cannot be used on receiver parameters (self, &self, &mut self)
+error: wasm_export parameter attributes cannot be used on receiver parameters (self, &self, &mut self)
   --> tests/unhappy/unchecked_param_type_on_self.test.rs:10:9
    |
 10 |         #[wasm_export(unchecked_param_type = "CustomType")]


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We need additional functionality in our wasm macro to update the function parameter names and parameter types in the generated JS code. The attributes used for making this happen were missing from the logic.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR adds `unchecked_param_type` and `js_name` attributes to the wasm macro to allow for forwarding over to wasm bindgen macro

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new parameter-level attributes `unchecked_param_type` and `js_name` in WebAssembly exports, enabling custom JavaScript type mapping and renaming of parameters and functions.

* **Bug Fixes**
  * Enhanced error messages for duplicate or invalid uses of `js_name` and `unchecked_param_type` attributes.
  * Disallowed use of `wasm_export` parameter attributes on receiver parameters (`self`, `&self`, `&mut self`).

* **Tests**
  * Expanded test coverage with multiple new cases demonstrating valid and invalid uses of `unchecked_param_type`, `js_name`, and `param_description` attributes, including error scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->