### PR TITLE
ci: auto-release on push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.PUBLISHER_SSH_KEY }}
-          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,30 +1,20 @@
-name: Release
+name: Package Release
 on:
-  workflow_dispatch:
-    inputs:
-      version-level:
-        description: 'Select Version Level'
-        required: true
-        type: choice
-        options:
-          - alpha   # Increase the alpha pre-version (x.y.z-alpha.M)
-          - beta    # Increase the beta pre-version (x.y.z-beta.M)
-          - patch   # Increase the patch version (x.y.z)
-          - minor   # Increase the minor version (x.y.0)
-          - major   # Increase the major version (x.0.0)
-          - release # Remove the pre-version, ie remove alpha/beta/rc (x.y.z)
-          - rc      # Increase the rc pre-version (x.y.z-rc.M)
-
+  push:
+    branches:
+      - main
 jobs:
   release:
+    if: ${{ github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'Package Release') }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          submodules: recursive
           ssh-key: ${{ secrets.PUBLISHER_SSH_KEY }}
-
+          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |
@@ -36,39 +26,46 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 1G
-
-      - run: nix develop -c rainix-rs-artifacts
       - run: nix develop -c rainix-rs-test
       - run: nix develop -c rainix-rs-static
-      - run: nix develop -c rainix-wasm-artifacts
       - run: nix develop -c rainix-wasm-test
-
       - name: Git Config
         run: |
           git config --global user.email "${{ secrets.CI_GIT_EMAIL }}"
           git config --global user.name "${{ secrets.CI_GIT_USER }}"
-
-      - name: Publish to crates.io
-        run: nix develop -c cargo release --no-confirm --execute --no-tag --workspace ${{ inputs.version-level }}
+      # Cargo hash detection — check both workspace members. Bump if either differs from the published version.
+      - name: Cargo hashes
+        id: cargo
+        run: |
+          changed=false
+          for pkg in wasm-bindgen-utils wasm-bindgen-utils-macros; do
+            NEW=$(nix develop -c cargo package -p "$pkg" --allow-dirty --quiet --list | LC_ALL=C sort | sha256sum | cut -d' ' -f1)
+            OLD_VERSION=$(curl -fsSL "https://crates.io/api/v1/crates/$pkg" | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_version'])" 2>/dev/null || echo "none")
+            if [ "$OLD_VERSION" = "none" ]; then
+              OLD="none"
+            else
+              curl -fsSL "https://crates.io/api/v1/crates/$pkg/$OLD_VERSION/download" -o /tmp/old.crate
+              OLD=$(tar -tzf /tmp/old.crate 2>/dev/null | LC_ALL=C sort | sha256sum | cut -d' ' -f1)
+            fi
+            echo "$pkg: old=$OLD new=$NEW"
+            if [ "$OLD" != "$NEW" ]; then changed=true; fi
+          done
+          echo "changed=$changed" >> $GITHUB_OUTPUT
+      - name: Bump and publish workspace
+        if: ${{ steps.cargo.outputs.changed == 'true' }}
+        run: |
+          nix develop -c cargo release --no-confirm --execute --no-tag --no-push --workspace alpha
+          echo "NEW_VERSION=v$(cargo pkgid -p wasm-bindgen-utils | cut -d@ -f2)" >> $GITHUB_ENV
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Get Version
-        run: echo "NEW_VERSION=v$(cargo pkgid | cut -d@ -f2 | cut -d' ' -f1)" >> $GITHUB_ENV
-
-      # Commit changes and tag
-      - name: Commit And Tag
-        run: git tag ${{ env.NEW_VERSION }}
-
-      # Push the commit to remote
-      - name: Push Changes To Remote
-        run: git push origin ${{ env.NEW_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Create gitHub release
-      - name: Create GitHub Release
-        id: gh_release
+      - name: Tag and push
+        if: ${{ steps.cargo.outputs.changed == 'true' }}
+        run: |
+          git tag ${{ env.NEW_VERSION }}
+          git push origin main
+          git push origin ${{ env.NEW_VERSION }}
+      - name: GitHub Release
+        if: ${{ steps.cargo.outputs.changed == 'true' }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.NEW_VERSION }}

--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1773213477,
-        "narHash": "sha256-Pv1Z3QqGkSGEUV+9pM5vYIiI7VJo7Tfm6ZmR+JSp1zo=",
+        "lastModified": 1778486972,
+        "narHash": "sha256-iuy/TbK9AbghEld2VSFuxyAF30LkOGUUdtrvixLfE7M=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "3c73daa86c823d706824fd9bbcb85aa23fd0f668",
+        "rev": "db117ae95a77b9ead24137c3ccb28896ae4fa4ec",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1774104215,
-        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -160,22 +160,6 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-old": {
-      "locked": {
-        "lastModified": 1749104371,
-        "narHash": "sha256-m2NmOPd6XgBiskmUq/BS9Xxuf3z0ebnGVfSKNAO5NEM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48975d7f9b9960ed33c4e8561bcce20cc0c2de5b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48975d7f9b9960ed33c4e8561bcce20cc0c2de5b",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1770073757,
@@ -194,11 +178,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1776017067,
-        "narHash": "sha256-oEp8fqJweZd5doqvH/aBAtc6NzZh+fh0tOhR09gQXck=",
+        "lastModified": 1778656924,
+        "narHash": "sha256-lKVrom9wOmpC3i7m+uBoGaBdW0PfH3QbLRG1XmuC6YA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a5a7cf16648d79134eb4da0e3354b08913917b2f",
+        "rev": "4ba039de0909446943c07e2b42bd2f0f4507072e",
         "type": "github"
       },
       "original": {
@@ -225,11 +209,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1771923393,
-        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
+        "lastModified": 1777641297,
+        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
+        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
         "type": "github"
       },
       "original": {
@@ -245,16 +229,15 @@
         "foundry": "foundry",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs_3",
-        "nixpkgs-old": "nixpkgs-old",
         "rust-overlay": "rust-overlay",
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1778595685,
-        "narHash": "sha256-lzDyw5XsH78MhDhmghFlK7wgp/6LPnB0weTKKCH0S6U=",
+        "lastModified": 1778696671,
+        "narHash": "sha256-egKixfe1+7/MtwhFjtfvGz+1eNtMQRNUdaWeR1GiXi0=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "486fdad30a417d06903b9afc52cec32e00d2d554",
+        "rev": "998bd91d4dbf8a28a32c7683d66624c91a907579",
         "type": "github"
       },
       "original": {
@@ -274,11 +257,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1773216618,
-        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
+        "lastModified": 1778642276,
+        "narHash": "sha256-bhk4lawR4ZnFhPtamB5WkCyvfgyZmsEUbWfT/3FRxFY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
+        "rev": "77265d2dc1e61b2abfd3b1d6609dbb66fe75e0a5",
         "type": "github"
       },
       "original": {
@@ -294,11 +277,11 @@
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1772085240,
-        "narHash": "sha256-+NEcuhT2A0QQumVx9Ze6g2iuNicyuW028Jq/HUJHGh4=",
+        "lastModified": 1777817996,
+        "narHash": "sha256-iI71iUhD7THLibl3w1JcQEhHmTwZMxChi70RTe33BAo=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "d3cc119973e484ea366f4b997b404bb00d7829ca",
+        "rev": "e3cf898cb804d5c0e5474b378a300fe8942e67d6",
         "type": "github"
       },
       "original": {
@@ -310,13 +293,13 @@
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-oEiXc95EghuYCudzkPA9XBFOnMdgWFfTO2/4XUfSTpc=",
+        "narHash": "sha256-zzwwHA2qPotv7yp8mK7+y9BZhm7ytuFeCJVvKBBdBn4=",
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
       }
     },
     "systems": {


### PR DESCRIPTION
## Summary
- Replace the manual \`workflow_dispatch\` Release workflow with rain.math.float's auto-release-on-main pattern.
- Each push to main hashes both crates (\`wasm-bindgen-utils\`, \`wasm-bindgen-utils-macros\`) via \`cargo package\` and compares against crates.io. If either differs, cargo-release bumps the workspace to a new alpha and publishes both crates + git tag + GitHub release.
- Skip-self check: commits with messages starting \`Package Release\` don't re-trigger.

## Why
Every meaningful merge currently sits as unreleased on main until someone remembers to fire the manual workflow. Float's hash-detection pattern means the artifact published to crates.io is always in sync with main.

## Notes
- Versions are always alpha bumps. If a non-alpha bump is needed for a specific release, run \`cargo release\` locally with the appropriate level and push the resulting tag.
- The 0.0.12 release from earlier in this session was triggered manually before this lands.

## Test plan
- [ ] First push to main after merge actually triggers a release and bumps versions
- [ ] Subsequent push with no package-content changes does NOT bump
- [ ] Release commit doesn't recursively trigger another release

🤖 Generated with [Claude Code](https://claude.com/claude-code)