### PR TITLE
test: refresh macrotest .expanded.rs snapshots for current toolchain

### DIFF
--- a/tests/happy/custom_tsify.test.expanded.rs
+++ b/tests/happy/custom_tsify.test.expanded.rs
@@ -111,6 +111,17 @@ const _: () = {
         }
     }
     #[automatically_derived]
+    impl wasm_bindgen::IntoJsGeneric for JsA
+    where
+        JsA: wasm_bindgen::JsGeneric,
+    {
+        type JsCanon = JsA;
+        #[inline]
+        fn to_js(self) -> JsA {
+            unsafe { core::mem::transmute_copy(&core::mem::ManuallyDrop::new(self)) }
+        }
+    }
+    #[automatically_derived]
     impl From<JsValue> for JsA {
         #[inline]
         fn from(obj: JsValue) -> Self {

--- a/tests/happy/custom_tsify_generic.test.expanded.rs
+++ b/tests/happy/custom_tsify_generic.test.expanded.rs
@@ -110,6 +110,17 @@ const _: () = {
         }
     }
     #[automatically_derived]
+    impl wasm_bindgen::IntoJsGeneric for JsA
+    where
+        JsA: wasm_bindgen::JsGeneric,
+    {
+        type JsCanon = JsA;
+        #[inline]
+        fn to_js(self) -> JsA {
+            unsafe { core::mem::transmute_copy(&core::mem::ManuallyDrop::new(self)) }
+        }
+    }
+    #[automatically_derived]
     impl From<JsValue> for JsA {
         #[inline]
         fn from(obj: JsValue) -> Self {


### PR DESCRIPTION
The latest-rainix bump (rust 1.94) changed macro expansion output, so the committed `custom_tsify` / `custom_tsify_generic` `.expanded.rs` snapshots went stale — `rs-test` is red on main and it also blocked the workspace autopublish (`cargo test --workspace`). Regenerated via `MACROTEST=overwrite`; `cargo test --workspace` passes.

Unblocks the `0.1.0` workspace publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)